### PR TITLE
Update met correction

### DIFF
--- a/Mods/BuildFile.xml
+++ b/Mods/BuildFile.xml
@@ -1,20 +1,13 @@
-<!-- flags CPPDEFINES="ELECTRON_CORRECTIONS_HEADER=${ELECTRON_CORRECTIONS_HEADER}"/--> 
-<!-- flags CPPDEFINES="PHOSPHOR_CORRECTIONS_HEADER=${PHOSPHOR_CORRECTIONS_HEADER}"/-->
-<!-- flags CPPDEFINES="PHOSPHOR_CORRECTIONS_SRC=${PHOSPHOR_CORRECTIONS_SRC}"/-->
 <use   name="MitCommon/MathTools"/>
 <use   name="MitAna/TreeMod"/>
 <use   name="MitPhysics/Init"/>
 <use   name="MitPhysics/Utils"/>
 <use   name="MitPhysics/ElectronLikelihood"/>
-<use   name="CondFormats/JetMETObjects"/>
-<use   name="FWCore/ParameterSet"/>
 <use   name="fastjet"/>
 <use   name="fastjet-contrib"/>
-<use   name="lhapdf"/>
 <use   name="root"/>
 <use   name="roottmva"/>
 <use   root=""/>
-<lib   name="EG"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/Mods/interface/JetIdMod.h
+++ b/Mods/interface/JetIdMod.h
@@ -87,6 +87,7 @@ namespace mithep {
 
     Bool_t IsGood(mithep::Jet const&) override;
     void IdBegin() override;
+    void IdTerminate() override;
 
     Double_t fJetEEMFractionMinCut = 0.01;  //jet Eem fraction min cut for calo jets
     Double_t fMinChargedHadronFraction = 0.;
@@ -105,6 +106,7 @@ namespace mithep {
     TString  fMVACutsFile = "";
     Bool_t   fUseClassicBetaForMVA = kFALSE; //set to true to replicate CMSSW PU jet ID on MiniAOD
 
+    Bool_t    fOwnJetIDMVA = kFALSE;
     JetIDMVA* fJetIDMVA = 0;
 
     ClassDef(JetIdMod, 0) // Jet identification module

--- a/Mods/interface/MetCorrectionMod.h
+++ b/Mods/interface/MetCorrectionMod.h
@@ -11,82 +11,124 @@
 #ifndef MITPHYSICS_MODS_METCORRECTIONMOD_H
 #define MITPHYSICS_MODS_METCORRECTIONMOD_H
 
-#include "MitAna/TreeMod/interface/BaseMod.h" 
-#include "MitAna/DataTree/interface/PFCandidateCol.h"
-#include "MitAna/DataTree/interface/PFMetCol.h"
-#include "MitAna/DataCont/interface/Types.h"
+#include "MitAna/TreeMod/interface/BaseMod.h"
+#include "MitPhysics/Utils/interface/JetCorrector.h"
+#include "MitAna/DataTree/interface/MetCol.h"
+#include "MitAna/DataTree/interface/PileupEnergyDensity.h"
+
+#include "MitAna/DataTree/interface/Names.h"
+#include "MitPhysics/Init/interface/ModNames.h"
 
 #include "TFormula.h"
 
-namespace mithep 
-{
-  class MetCorrectionMod : public BaseMod
-  {
-    public:
-      MetCorrectionMod(const char *name="MetCorrectionMod", 
-		       const char *title="Met correction module");
-     ~MetCorrectionMod();
+namespace mithep {
 
-      const char   *GetInputName()                 const     { return fMetName;          }   
-      const char   *GetCorrectedName()             const     { return fCorrectedMetName; }     
-      const char   *GetJetsName()                  const     { return fJetsName;         }   
-      const char   *GetCorrectedJetsName()         const     { return fCorrectedJetsName;}     
-      const char   *GetOutputName()                const     { return GetCorrectedName();}
-      Double_t     GetMinDz()                      const     { return fMinDz;            }
-      const char   *GetExprType0()                 const     { return fExprType0;        }
-      const char   *GetExprShiftDataPx()           const     { return fExprShiftDataPx;  }
-      const char   *GetExprShiftDataPy()           const     { return fExprShiftDataPy;  }
-      const char   *GetExprShiftMCPx()             const     { return fExprShiftMCPx;    }
-      const char   *GetExprShiftMCPy()             const     { return fExprShiftMCPy;    }
-      void         SetInputName(const char *name)            { fMetName = name;          }
-      void         SetCorrectedName(const char *name)        { fCorrectedMetName = name; }    
-      void         SetOutputName(const char *name)           { fCorrectedMetName = name; }    
-      void         SetJetsName(const char *name)             { fJetsName = name;         }     
-      void         SetCorrectedJetsName(const char *name)    { fCorrectedJetsName = name;}     
-      void         SetMinDz(Double_t d)                      { fMinDz = d;               }     
-      void         ApplyType0(bool b)                        { fApplyType0 = b;          }     
-      void         ApplyType1(bool b)                        { fApplyType1 = b;          }
-      void         ApplyShift(bool b)                        { fApplyShift = b;          }
-      void         SetExprType0(const char *expr)            { fExprType0 = expr;        }
-      void         SetExprShiftDataPx(const char *expr)      { fExprShiftDataPx = expr;  }
-      void         SetExprShiftDataPy(const char *expr)      { fExprShiftDataPy = expr;  }
-      void         SetExprShiftMCPx(const char *expr)        { fExprShiftMCPx = expr;    }
-      void         SetExprShiftMCPy(const char *expr)        { fExprShiftMCPy = expr;    }   
-      void         IsData(bool b)                            { fIsData = b;              }
-      void         SetPrint(bool b)                          { fPrint = b;               }
+  // (Get|Set)ExprShift(Data|MC)P(x|y) is removed. Use IsData flag + (Get|Set)ExprShiftP(x|y) instead.
 
-    protected:
-      void                  SlaveBegin();
-      void                  SlaveTerminate();
-      void                  Process();
-      
-      TString               fMetName;            //name of met collection (input)
-      TString               fCorrectedMetName;   //name of corrected met collection (output)
-      TString               fJetsName;           //name of uncorrected jet collection (input)
-      TString               fCorrectedJetsName;  //name of corrected jet collection (input)
-      TString               fPFCandidatesName;   //name of PF candidates collection (input)
-      TString               fVertexName;         //name of vertex collection (input)
-      Double_t              fMinDz;              //delta Z for separating PU verteces from PV
-                           
-      bool                  fApplyType0;         //switch on type 0 correction
-      bool                  fApplyType1;         //switch on type 1 correction
-      bool                  fApplyShift;         //switch on XY shift correction
-                                    
-      TString               fExprType0;          //expr for type0 correction
-      TFormula             *fFormulaType0;       //formula for type0 correction
-      TString               fExprShiftDataPx;    //expr for shift correction (data)
-      TFormula             *fFormulaShiftDataPx; //formula for type0 correction
-      TString               fExprShiftDataPy;    //expr for shift correction (data)
-      TFormula             *fFormulaShiftDataPy; //formula for type0 correction
-      TString               fExprShiftMCPx;      //expr for shift correction (MC)
-      TFormula             *fFormulaShiftMCPx;   //formula for type0 correction
-      TString               fExprShiftMCPy;      //expr for shift correction (MC)
-      TFormula             *fFormulaShiftMCPy;   //formula for type0 correction
-                                    
-      bool                  fIsData;             //flag for data/MC distinction
-      bool                  fPrint;              //flag for debug print out
-                           
-      ClassDef(MetCorrectionMod, 1)              // met correction module
+  class MetCorrectionMod : public BaseMod {
+  public:
+    MetCorrectionMod(const char* name="MetCorrectionMod",
+                     const char* title="Met correction module");
+    ~MetCorrectionMod() {}
+
+    const char*   GetInputName() const       { return fMetName; }
+    const char*   GetOutputName() const      { return fOutput.GetName(); }
+    const char*   GetCorrectedName() const   { return GetOutputName(); }
+    const char*   GetJetsName() const        { return fJetsName; }
+    Double_t      GetMinDz() const           { return fMinDz; }
+    const char*   GetExprType0();
+    const char*   GetExprShiftPx();
+    const char*   GetExprShiftPy();
+    JetCorrector* GetJetCorrector() const    { return fJetCorrector; }
+    UInt_t        GetRhoAlgo() const         { return fRhoAlgo; }
+    Double_t      GetMaxEMFraction() const   { return fMaxEMFraction; }
+    Bool_t        GetSkipMuons() const       { return fSkipMuons; }
+
+    void SetInputName(const char *name)        { fMetName = name; }
+    void SetOutputName(const char *name)       { fOutput.SetName(name); }
+    void SetCorrectedName(const char *name)    { SetOutputName(name); }
+    void SetJetsName(const char *name)         { fJetsName = name; }
+    void SetMinDz(Double_t d)                  { fMinDz = d; }
+    void ApplyType0(bool b)                    { fApplyType0 = b; }
+    void ApplyType1(bool b)                    { fApplyType1 = b; }
+    void ApplyShift(bool b)                    { fApplyShift = b; }
+    void SetExprType0(const char *expr)        { MakeFormula(0, expr); }
+    void SetPFCandidatesName(const char *name) { fPFCandidatesName = name; }
+    void SetExprShiftPx(const char *expr)  { MakeFormula(1, expr); }
+    void SetExprShiftPy(const char *expr)  { MakeFormula(2, expr); }
+    void AddJetCorrectionFromFile(char const* file);
+    void SetJetCorrector(JetCorrector*);
+    void SetRhoAlgo(UInt_t a)                  { fRhoAlgo = a; }
+    void SetMaxEMFraction(Double_t m)          { fMaxEMFraction = m; }
+    void SetSkipMuons(Bool_t s)                { fSkipMuons = s; }
+    void IsData(bool b)                        { fIsData = b; }
+    void SetPrint(bool b)                      { fPrint = b; }
+
+  protected:
+    void SlaveBegin() override;
+    void SlaveTerminate() override;
+    void Process() override;
+
+    void MakeJetCorrector();
+    void MakeFormula(UInt_t idx, char const* expr = "");
+
+    TString       fMetName{"PFMet"};                           //name of met collection (input)
+    TString       fJetsName{Names::gkPFJetBrn};                //name of uncorrected jet collection (input)
+    TString       fPFCandidatesName{Names::gkPFCandidatesBrn}; //name of PF candidates collection (input)
+    TString       fVertexName{ModNames::gkGoodVertexesName};   //name of vertex collection (input)
+    Double_t      fMinDz = 0.2;                                //delta Z for separating PU verteces from PV
+                  
+    Bool_t        fApplyType0 = kTRUE; //switch on type 0 correction
+    Bool_t        fApplyType1 = kTRUE; //switch on type 1 correction
+    Bool_t        fApplyShift = kTRUE; //switch on XY shift correction
+                  
+    TFormula*     fFormulaType0 = 0;
+    TFormula*     fFormulaShiftPx = 0;
+    TFormula*     fFormulaShiftPy = 0;
+
+    Bool_t        fOwnJetCorrector = kFALSE;
+    JetCorrector* fJetCorrector = 0; //For type 1 correction. Can be created internally or set externally
+    UInt_t        fRhoAlgo = PileupEnergyDensity::kFixedGridFastjetAll;
+
+    Double_t      fMaxEMFraction = -1.; //maximum charged + neutral EM energy fraction
+                                        //for jet to be in Type1 corr (< 0 -> does not skip jets)
+    Bool_t        fSkipMuons = kFALSE; //remove muon P4 from jet P4 in Type 1 corr
+                  
+    Bool_t        fIsData = kTRUE; //flag for data/MC distinction
+    Bool_t        fPrint = kFALSE; //flag for debug print out
+
+    MetOArr       fOutput{1, "PFMetT0T1Shift"}; //using ObjArray to accomodate different MET types
+
+    ClassDef(MetCorrectionMod, 1) // met correction module
   };
+
 }
+
+inline
+char const*
+mithep::MetCorrectionMod::GetExprType0()
+{
+  if (!fFormulaType0)
+    MakeFormula(0);
+  return fFormulaType0->GetExpFormula();
+}
+
+inline
+char const*
+mithep::MetCorrectionMod::GetExprShiftPx()
+{
+  if (!fFormulaShiftPx)
+    MakeFormula(1);
+  return fFormulaShiftPx->GetExpFormula();
+}
+
+inline
+char const*
+mithep::MetCorrectionMod::GetExprShiftPy()
+{
+  if (!fFormulaShiftPy)
+    MakeFormula(2);
+  return fFormulaShiftPy->GetExpFormula();
+}
+
 #endif

--- a/Mods/src/JetCorrectionMod.cc
+++ b/Mods/src/JetCorrectionMod.cc
@@ -1,11 +1,7 @@
 #include "MitPhysics/Mods/interface/JetCorrectionMod.h"
-#include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
-#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
-#include "MitCommon/MathTools/interface/MathUtils.h"
+
 #include "MitAna/DataTree/interface/JetCol.h"
-#include "MitAna/DataTree/interface/CaloJetCol.h"
-#include "MitPhysics/Init/interface/ModNames.h"
+#include "MitAna/DataTree/interface/PileupEnergyDensityCol.h"
 
 using namespace mithep;
 
@@ -13,22 +9,9 @@ ClassImp(mithep::JetCorrectionMod)
 
 //--------------------------------------------------------------------------------------------------
 JetCorrectionMod::JetCorrectionMod(const char *name, const char *title) : 
-  BaseMod(name,title),
-  fJetsName(ModNames::gkPubJetsName),
-  fCorrectedJetsName(ModNames::gkCorrectedJetsName),  
-  fRhoBranchName("Rho"),
-  fEnabledL1Correction(kFALSE),
-  rhoEtaMax(5.0),
-  fJetCorrector(0),
-  fRhoAlgo(mithep::PileupEnergyDensity::kHighEta)
+  BaseMod(name, title)
 {
-  // Constructor.
-}
-
-//--------------------------------------------------------------------------------------------------
-JetCorrectionMod::~JetCorrectionMod()
-{
-  delete fJetCorrector;
+  fCorrectedJets.SetOwner(true);
 }
 
 void
@@ -60,51 +43,33 @@ mithep::JetCorrectionMod::SetRhoType(RhoUtilities::RhoType type)
 }   
 
 //--------------------------------------------------------------------------------------------------
-void JetCorrectionMod::SlaveBegin()
+void
+JetCorrectionMod::SlaveBegin()
 {
-  //fill JetCorrectorParameters from files
-  std::vector<JetCorrectorParameters> correctionParameters;
-  for (std::vector<std::string>::const_iterator it = fCorrectionFiles.begin(); it!=fCorrectionFiles.end(); ++it) {
-    correctionParameters.push_back(JetCorrectorParameters(*it));
-  }
-  
-  //initialize jet corrector class
-  fJetCorrector = new FactorizedJetCorrector(correctionParameters);
+  // fCorrector = 0 is alllowed but should not happen here - the module is useless in this case
+  MakeCorrector();
 
-  //keep track of which corrections are enabled
-  for (std::vector<JetCorrectorParameters>::const_iterator it = correctionParameters.begin(); it != correctionParameters.end(); ++it) {
-    std::string ss = it->definitions().level();
-    if      (ss == "L1Offset")
-      fEnabledCorrectionMask.SetBit(Jet::L1);    
-    else if (ss == "L1FastJet")
-      fEnabledCorrectionMask.SetBit(Jet::L1);    
-    else if (ss == "L2Relative")
-      fEnabledCorrectionMask.SetBit(Jet::L2);
-    else if (ss == "L3Absolute")
-      fEnabledCorrectionMask.SetBit(Jet::L3);
-    else if (ss == "L4EMF")
-      fEnabledCorrectionMask.SetBit(Jet::L4);
-    else if (ss == "L5Flavor")
-      fEnabledCorrectionMask.SetBit(Jet::L5);
-    else if (ss == "L6SLB")
-      fEnabledCorrectionMask.SetBit(Jet::L6);
-    else if (ss == "L7Parton")
-      fEnabledCorrectionMask.SetBit(Jet::L7);
-  }
+  fCorrector->Initialize();
 
-  for (UInt_t l=0; l<8; l=l+1) {
-    if (fEnabledCorrectionMask.TestBit(l)) {
-      fEnabledCorrections.push_back(Jet::ECorr(l));
-    }
+  PublishObj(&fCorrectedJets);
+}
+
+void JetCorrectionMod::SlaveTerminate()
+{
+  RetractObj(fCorrectedJets.GetName());
+
+  if (fOwnCorrector) {
+    delete fCorrector;
+    fCorrector = 0;
   }
 }
 
 //--------------------------------------------------------------------------------------------------
-void JetCorrectionMod::Process()
+void 
+JetCorrectionMod::Process()
 {
   // Process entries of the tree. 
-
-  const JetCol *inJets = GetObject<JetCol>(fJetsName);
+  auto* inJets = GetObject<JetCol>(fJetsName);
   if (!inJets) {
     SendError(kAbortModule, "Process", 
               "Pointer to input jet collection %s is null.",
@@ -112,92 +77,62 @@ void JetCorrectionMod::Process()
     return;
   }
 
-  JetOArr *CorrectedJets = new JetOArr;
-  CorrectedJets->SetOwner(kTRUE);
-  CorrectedJets->SetName(fCorrectedJetsName);
-
   // get the energy density from the event
-  auto* rho = GetObject<PileupEnergyDensityCol>(fRhoBranchName);
+  auto* rhocol = GetObject<PileupEnergyDensityCol>(fRhoBranchName);
+  double rho = 0.;
+  if (rhocol) {
+    rho = rhocol->At(0)->Rho(fRhoAlgo);
+  }
+  else if (fCorrector->IsEnabled(Jet::L1)) {
+    SendError(kAbortModule, "Process", 
+              "Pointer to input rho collection %s is null.",
+              fRhoBranchName.Data());
+    return;
+  }
+
+  fCorrectedJets.Reset();
 
   // loop over jets
-  for (UInt_t i=0; i<inJets->GetEntries(); ++i) {
-
-    const Jet *inJet = inJets->At(i);
-
+  for (unsigned iJ = 0; iJ != inJets->GetEntries(); ++iJ) {
     //copy input jet, using special function to copy full derived class
-    Jet *jet = inJet->MakeCopy();
+    Jet* jet = inJets->At(iJ)->MakeCopy();
 
-    //cache uncorrected momentum
-    const FourVectorM rawMom = jet->RawMom();
-
-    //compute correction factors
-    fJetCorrector->setJetEta(rawMom.Eta());
-    fJetCorrector->setJetPt(rawMom.Pt());
-    fJetCorrector->setJetPhi(rawMom.Phi());
-    fJetCorrector->setJetE(rawMom.E());
-    const PileupEnergyDensity *fR = rho->At(0);
-
-    Double_t theRho = fR->Rho(fRhoAlgo);
-
-    fJetCorrector->setRho(theRho);
-    fJetCorrector->setJetA(jet->JetArea());
-    
-    //emf only valid for CaloJets
-    const CaloJet *caloJet = dynamic_cast<const CaloJet*>(jet);
-    if (caloJet) {
-      fJetCorrector->setJetEMF(caloJet->EnergyFractionEm());
-    }
-    else {
-      fJetCorrector->setJetEMF(-99.0);
-    }
-    std::vector<float>&& corrections = fJetCorrector->getSubCorrections();
-    
-    //set and enable correction factors in the output jet
-    Double_t cumulativeCorrection = 1.0;
-
-    for (UInt_t j=0; j<corrections.size(); ++j) {
-      Double_t currentCorrection = corrections.at(j)/cumulativeCorrection;
-      cumulativeCorrection = corrections.at(j);
-      Jet::ECorr currentLevel = fEnabledCorrections.at(j);
-      if (currentLevel==Jet::L1)
-        jet->SetL1OffsetCorrectionScale(currentCorrection);
-      else if (currentLevel==Jet::L2)
-        jet->SetL2RelativeCorrectionScale(currentCorrection);
-      else if (currentLevel==Jet::L3)
-        jet->SetL3AbsoluteCorrectionScale(currentCorrection);
-      else if (currentLevel==Jet::L4)
-        jet->SetL4EMFCorrectionScale(currentCorrection);
-      else if (currentLevel==Jet::L5)
-        jet->SetL5FlavorCorrectionScale(currentCorrection);
-      else if (currentLevel==Jet::L6)
-        jet->SetL6LSBCorrectionScale(currentCorrection);
-      else if (currentLevel==Jet::L7)
-        jet->SetL7PartonCorrectionScale(currentCorrection);
-
-      //enable corrections after setting them
-      jet->EnableCorrection(currentLevel);
-    }
+    fCorrector->Correct(*jet, rho);
 
     // add corrected jet to collection
-    CorrectedJets->AddOwned(jet);             
+    fCorrectedJets.AddOwned(jet);             
   }
 
   // sort according to ptrootcint forward declaration data members
-  CorrectedJets->Sort();
-  
-  // add to event for other modules to use
-  AddObjThisEvt(CorrectedJets);
+  fCorrectedJets.Sort();
 }
 
 //--------------------------------------------------------------------------------------------------
-void JetCorrectionMod::AddCorrectionFromRelease(const std::string &path)
+void
+JetCorrectionMod::AddCorrectionFromFile(char const* fileName)
 {
-  edm::FileInPath file(path);
-  AddCorrectionFromFile(file.fullPath());
+  MakeCorrector();
+  fCorrector->AddParameterFile(fileName);
 }
 
 //--------------------------------------------------------------------------------------------------
-void JetCorrectionMod::AddCorrectionFromFile(const std::string &file)
+void
+JetCorrectionMod::SetCorrector(JetCorrector* corr)
 {
-  fCorrectionFiles.push_back(file);
+  if (fCorrector && fOwnCorrector) {
+    SendError(kAbortAnalysis, "SetCorrector", "Corrector already created");
+  }
+  else {
+    fCorrector = corr;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+void
+JetCorrectionMod::MakeCorrector()
+{
+  if (!fCorrector) {
+    fCorrector = new JetCorrector;
+    fOwnCorrector = true;
+  }
 }

--- a/Mods/src/JetIdMod.cc
+++ b/Mods/src/JetIdMod.cc
@@ -23,6 +23,8 @@ mithep::JetIdMod::IdBegin()
   if (fMVATrainingSet != JetIDMVA::nMVATypes && !fJetIDMVA) {
     fJetIDMVA = new JetIDMVA();
     fJetIDMVA->Initialize(JetIDMVA::CutType(fMVACutWP), JetIDMVA::MVAType(fMVATrainingSet), fMVAWeightsFile, fMVACutsFile);
+
+    fOwnJetIDMVA = true;
   }
 
   if (fJetIDMVA && !fJetIDMVA->IsInitialized())
@@ -44,6 +46,15 @@ mithep::JetIdMod::IdBegin()
   xaxis->SetBinLabel(cPFLooseId + 1, "PFLooseId");
   xaxis->SetBinLabel(cBeta + 1, "Beta");
   xaxis->SetBinLabel(cMVA + 1, "MVA");
+}
+
+void
+mithep::JetIdMod::IdTerminate()
+{
+  if (fOwnJetIDMVA) {
+    delete fJetIDMVA;
+    fJetIDMVA = 0;
+  }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Utils/dict/MitPhysicsUtilsLinkDef.h
+++ b/Utils/dict/MitPhysicsUtilsLinkDef.h
@@ -13,6 +13,7 @@
 #include "MitPhysics/Utils/interface/PhotonTools.h"
 #include "MitPhysics/Utils/interface/RecoilTools.h"
 #include "MitPhysics/Utils/interface/JetTools.h"
+#include "MitPhysics/Utils/interface/JetCorrector.h"
 #include "MitPhysics/Utils/interface/MetLeptonTools.h"
 #include "MitPhysics/Utils/interface/VertexTools.h"
 #include "MitPhysics/Utils/interface/VertexMVA.h"
@@ -58,6 +59,7 @@
 #pragma link C++ class mithep::PhotonTools;
 #pragma link C++ class mithep::RecoilTools;
 #pragma link C++ class mithep::JetTools;
+#pragma link C++ class mithep::JetCorrector;
 #pragma link C++ class mithep::MetLeptonTools;
 #pragma link C++ class mithep::VertexTools;
 #pragma link C++ class mithep::VertexMVA;

--- a/Utils/interface/JetCorrector.h
+++ b/Utils/interface/JetCorrector.h
@@ -1,0 +1,57 @@
+//--------------------------------------------------------------------------------------------------
+// JetCorrector
+//
+// A FactorizedJetCorrector wrapper. Used by JetCorrectionMod and MetCorrectionMod (and possibly
+// by other modules)
+//
+// Authors: Y.Iiyama
+//--------------------------------------------------------------------------------------------------
+
+#ifndef MITPHYSICS_UTILS_JETCORRECTOR_H
+#define MITPHYSICS_UTILS_JETCORRECTOR_H
+
+#include "MitAna/DataTree/interface/Jet.h"
+
+#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+
+#include <vector>
+#include <algorithm>
+
+class FactorizedJetCorrector;
+
+namespace mithep {
+
+  class JetCorrector {
+  public:
+    JetCorrector() {}
+    virtual ~JetCorrector();
+
+    void AddParameterFile(char const* fileName);
+    void SetMaxCorrLevel(mithep::Jet::ECorr m) { fMaxCorrLevel = m; }
+    void Initialize();
+
+    std::vector<mithep::Jet::ECorr> const& GetLevels() const { return fLevels; }
+    mithep::Jet::ECorr GetMaxCorrLevel() const { return fMaxCorrLevel; }
+    // Returns a vector of cumulative corrections, e.g. {L1, L1*L2, L1*L2*L3, ...}
+    std::vector<Float_t> CorrectionFactors(mithep::Jet&, Double_t rho = 0.) const;
+    // Returns the full correction (i.e. the last element of CorrectionFactors)
+    Float_t CorrectionFactor(mithep::Jet&, Double_t rho = 0.) const;
+    void Correct(mithep::Jet&, Double_t rho = 0.) const;
+    Bool_t IsInitialized() const { return fCorrector != 0; }
+    Bool_t IsEnabled(mithep::Jet::ECorr l) const
+    { return l < fMaxCorrLevel && std::find(fLevels.begin(), fLevels.end(), l) != fLevels.end(); }
+
+    static mithep::Jet::ECorr TranslateLevel(char const* levelName);
+
+  private:
+    std::vector<JetCorrectorParameters> fParameters = {};
+    std::vector<mithep::Jet::ECorr> fLevels = {};
+    mithep::Jet::ECorr fMaxCorrLevel = mithep::Jet::nECorrs;
+    FactorizedJetCorrector* fCorrector = 0;
+
+    ClassDef(JetCorrector, 0)
+  };
+
+}
+
+#endif

--- a/Utils/src/JetCorrector.cc
+++ b/Utils/src/JetCorrector.cc
@@ -1,0 +1,136 @@
+#include "MitPhysics/Utils/interface/JetCorrector.h"
+#include "MitAna/DataTree/interface/CaloJet.h"
+#include "MitAna/DataTree/interface/ObjTypes.h"
+
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
+
+#include <stdexcept>
+
+ClassImp(mithep::JetCorrector)
+
+mithep::JetCorrector::~JetCorrector()
+{
+  delete fCorrector;
+}
+
+void
+mithep::JetCorrector::AddParameterFile(char const* fileName)
+{
+  try {
+    fParameters.emplace_back(std::string(fileName));
+  }
+  catch (std::exception& ex) {
+    std::cerr << "Exception in JetCorrector::AddParameterFile(" << fileName << "):" << std::endl;
+    std::cerr << ex.what() << std::endl;
+    throw;
+  }
+
+  auto it = fParameters.rbegin();
+  mithep::Jet::ECorr lastLevel = TranslateLevel(it->definitions().level().c_str());
+  fLevels.push_back(lastLevel);
+
+  // check correction ordering
+  if (fParameters.size() > 1) {
+    ++it;
+    if (TranslateLevel(it->definitions().level().c_str()) >= lastLevel) {
+      std::cerr << "Exception in JetCorrector::AddParameterFile(" << fileName << "):" << std::endl;
+      std::cerr << "Correction parameters must be added in ascending order of correction levels" << std::endl;
+      throw std::runtime_error("Configuration error");
+    }
+  }
+}
+
+void
+mithep::JetCorrector::Initialize()
+{
+  fCorrector = new FactorizedJetCorrector(fParameters);
+}
+
+std::vector<Float_t>
+mithep::JetCorrector::CorrectionFactors(mithep::Jet& jet, Double_t rho/* = 0.*/) const
+{
+  if (!IsInitialized())
+    throw std::runtime_error("JetCorrector not initialized");
+
+  auto&& rawMom = jet.RawMom();
+
+  //compute correction factors
+  fCorrector->setJetEta(rawMom.Eta());
+  fCorrector->setJetPt(rawMom.Pt());
+  fCorrector->setJetPhi(rawMom.Phi());
+  fCorrector->setJetE(rawMom.E());
+
+  fCorrector->setRho(rho);
+  fCorrector->setJetA(jet.JetArea());
+    
+  //emf only valid for CaloJets
+  if (jet.ObjType() == mithep::kCaloJet)
+    fCorrector->setJetEMF(static_cast<mithep::CaloJet&>(jet).EnergyFractionEm());
+  else
+    fCorrector->setJetEMF(-99.0);
+
+  std::vector<float>&& corrections = fCorrector->getSubCorrections();
+  if (fMaxCorrLevel != Jet::nECorrs) {
+    for (unsigned iL = 1; iL <= fLevels.size(); ++iL) {
+      if (fLevels[iL - 1] == fMaxCorrLevel) {
+        corrections.resize(iL);
+        break;
+      }
+    }
+  }
+
+  return corrections;
+}
+
+Float_t
+mithep::JetCorrector::CorrectionFactor(mithep::Jet& jet, Double_t rho/* = 0.*/) const
+{
+  auto&& factors(CorrectionFactors(jet, rho));
+  if (factors.size() != 0)
+    return factors.back();
+  else
+    return 1.;
+}
+
+void
+mithep::JetCorrector::Correct(mithep::Jet& jet, Double_t rho/* = 0.*/) const
+{
+  auto&& corrections(CorrectionFactors(jet, rho));
+
+  //set and enable correction factors in the output jet
+  double cumulativeCorrection = 1.0;
+
+  for (unsigned iC = 0; iC != corrections.size(); ++iC) {
+    float currentCorrection = corrections.at(iC) / cumulativeCorrection;
+    cumulativeCorrection = corrections.at(iC);
+
+    //set correction and enable
+    jet.SetCorrectionScale(currentCorrection, fLevels.at(iC));
+    jet.EnableCorrection(fLevels.at(iC));
+  }
+}
+
+/*static*/
+mithep::Jet::ECorr
+mithep::JetCorrector::TranslateLevel(char const* levelName)
+{
+  std::string name(levelName);
+  if (name == "L1Offset" || name == "L1FastJet" || name == "L1JPTOffset")
+    return mithep::Jet::L1;
+  else if (name == "L2Relative")
+    return mithep::Jet::L2;
+  else if (name == "L3Absolute")
+    return mithep::Jet::L3;
+  else if (name == "L4EMF")
+    return mithep::Jet::L4;
+  else if (name == "L5Flavor")
+    return mithep::Jet::L5;
+  else if (name == "L6SLB")
+    return mithep::Jet::L6;
+  else if (name == "L7Parton")
+    return mithep::Jet::L7;
+  else {
+    std::cerr << "Exception in JetCorrector::TranslateLevel(): Unknown correction level " << name << std::endl;
+    throw std::runtime_error("Unknown correction");
+  }
+}


### PR DESCRIPTION
Updated MetCorrectionMod to synchronize with the MET correction implementation in CMSSW.
Only type 1 correction is validated.
The previous implementation was using a raw jet collection and corrected jet collection, taking the momenta difference and using them as the MET correction.
The CMSSW implementation does something a little more sophisticated, and requires to correct the jets on the fly. To avoid duplicating the code between JetCorrectionMod and MetCorrectionMod, jet correction was therefore moved to a new class JetCorrector, which gets used by the two modules.
