### PR TITLE
adding example python configurations

### DIFF
--- a/Mods/python/ElectronIdMod.py
+++ b/Mods/python/ElectronIdMod.py
@@ -1,0 +1,12 @@
+from MitAna.TreeMod.bambu import mithep
+
+electronIdMod = mithep.ElectronIdMod(
+    OutputName = 'VetoElectrons',
+    IdType = mithep.ElectronTools.kPhys14Veto,
+    IsoType = mithep.ElectronTools.kPhys14VetoIso,
+    ApplyEcalFiducial = True,
+    WhichVertex = 0,
+    PtMin = 10.,
+    EtaMax = 2.5,
+    ConversionsName = 'Conversions'
+)

--- a/Mods/python/GoodPVFilterMod.py
+++ b/Mods/python/GoodPVFilterMod.py
@@ -1,0 +1,10 @@
+from MitAna.TreeMod.bambu import mithep
+
+goodPVFilterMod = mithep.GoodPVFilterMod(
+    MinVertexNTracks = 0,
+    MinNDof = 4,
+    MaxAbsZ = 24.,
+    MaxRho = 2.,
+    IsMC = True,
+    VertexesName = mithep.Names.gkPVBrn
+)

--- a/Mods/python/JetCorrectionMod.py
+++ b/Mods/python/JetCorrectionMod.py
@@ -1,0 +1,13 @@
+from MitAna.TreeMod.bambu import mithep
+import os
+
+jetCorrectionMod = mithep.JetCorrectionMod(
+    InputName = 'AKt4PFJetsCHS',
+    CorrectedJetsName = 'CorrectedJets',
+    RhoAlgo = mithep.PileupEnergyDensity.kFixedGridFastjetAll
+)
+jetCorrectionMod.AddCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L1FastJet_AK4PFchs.txt")
+jetCorrectionMod.AddCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L2Relative_AK4PFchs.txt")
+jetCorrectionMod.AddCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L3Absolute_AK4PFchs.txt")
+# currently correction file must be added in L1-L2-L3 order and cannot be removed
+# -> will have to copy-paste this code to use any other jet collection / correction..

--- a/Mods/python/JetIdMod.py
+++ b/Mods/python/JetIdMod.py
@@ -1,0 +1,20 @@
+from MitAna.TreeMod.bambu import mithep
+import os
+
+jetIdMod = mithep.JetIdMod(
+    InputName = mithep.ModNames.gkCorrectedJetsName,
+    OutputName = 'GoodJets',
+    ApplyPFLooseId = True,
+    MVATrainingSet = mithep.JetIDMVA.k53BDTCHSFullPlusRMS,
+    MVACutWP = mithep.JetIDMVA.kLoose,
+    MVAWeightsFile = os.environ['MIT_DATA'] + '/TMVAClassification_5x_BDT_chsFullPlusRMS.weights.xml',
+    MVACutsFile = os.environ['MIT_DATA'] + '/jetIDCuts_121221.dat',
+    UseClassicBetaForMVA = True,
+    PtMin = 30.,
+    EtaMax = 2.5
+)
+
+# UseClassicBetaForMVA: set to true for MiniAOD input. Makes the MVA value agree
+# with what CMSSW would give if Jet Id was calculated on MiniAOD. This is not the
+# same as the pre-calculated MVA value stored in MiniAOD and accessible with
+# jet.userFloat().

--- a/Mods/python/MetCorrectionMod.py
+++ b/Mods/python/MetCorrectionMod.py
@@ -1,0 +1,18 @@
+from MitAna.TreeMod.bambu import mithep
+import os
+
+metCorrectionMod = mithep.MetCorrectionMod(
+    InputName = 'PFMet',
+    OutputName = 'PFType1CorrectedMet',
+    JetsName = 'AKt4PFJets',
+    RhoAlgo = mithep.PileupEnergyDensity.kFixedGridFastjetAll,
+    MaxEMFraction = 0.9,
+    SkipMuons = True
+)
+metCorrectionMod.ApplyType0(False)
+metCorrectionMod.ApplyType1(True)
+metCorrectionMod.ApplyShift(False)
+metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L1FastJet_AK4PF.txt")
+metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L2Relative_AK4PF.txt")
+metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L3Absolute_AK4PF.txt")
+metCorrectionMod.IsData(False)

--- a/Mods/python/MuonIdMod.py
+++ b/Mods/python/MuonIdMod.py
@@ -1,0 +1,11 @@
+from MitAna.TreeMod.bambu import mithep
+
+muonIdMod = mithep.MuonIdMod(
+    OutputName = 'LooseMuons',
+    IdType = mithep.MuonTools.kNoId,
+    IsoType = mithep.MuonTools.kPFIsoBetaPUCorrected,
+    PFNoPileupCandidatesName = 'pfNoPU',
+    PFPileupCandidatesName = 'pfPU',
+    PtMin = 10.,
+    EtaMax = 2.4
+)

--- a/Mods/python/PFTauIdMod.py
+++ b/Mods/python/PFTauIdMod.py
@@ -1,0 +1,9 @@
+from MitAna.TreeMod.bambu import mithep
+
+pfTauIdMod = mithep.PFTauIdMod(
+    OutputName = 'LooseTaus',
+    PtMin = 18.,
+    EtaMax = 2.3
+)
+pfTauIdMod.AddDiscriminator(mithep.PFTau.kDiscriminationByDecayModeFindingNewDMs)
+

--- a/Mods/python/PhotonIdMod.py
+++ b/Mods/python/PhotonIdMod.py
@@ -1,0 +1,9 @@
+from MitAna.TreeMod.bambu import mithep
+
+photonIdMod = mithep.PhotonIdMod(
+    OutputName = 'LoosePhotons',
+    IdType = mithep.PhotonTools.kPhys14Loose,
+    IsoType = mithep.PhotonTools.kPhys14Loose,
+    PtMin = 15.,
+    EtaMax = 2.5
+)

--- a/Mods/python/SeparatePileUpMod.py
+++ b/Mods/python/SeparatePileUpMod.py
@@ -1,0 +1,7 @@
+from MitAna.TreeMod.bambu import mithep
+
+separatePileUpMod = mithep.SeparatePileUpMod(
+    PFNoPileUpName = "pfNoPU",
+    PFPileUpName = "pfPU",
+    CheckClosestZVertex = False
+)

--- a/Mods/python/__init__.py
+++ b/Mods/python/__init__.py
@@ -1,3 +1,0 @@
-#Automatically created by SCRAM
-import os
-__path__.append(os.path.dirname(os.path.abspath(__file__).rsplit('/MitPhysics/Mods/',1)[0])+'/cfipython/slc6_amd64_gcc491/MitPhysics/Mods')

--- a/Mods/python/__init__.py
+++ b/Mods/python/__init__.py
@@ -1,0 +1,3 @@
+#Automatically created by SCRAM
+import os
+__path__.append(os.path.dirname(os.path.abspath(__file__).rsplit('/MitPhysics/Mods/',1)[0])+'/cfipython/slc6_amd64_gcc491/MitPhysics/Mods')


### PR DESCRIPTION
Added importable python configurations for some of the modules under Mods. Can be used as examples to copy-paste to user macro, or simply be imported and used directly:

```
from MitPhysics.Mods.JetIdMod import jetIdMod
jetIdMod.SetMVACutWP = mithep.JetIDMVA.kTight
```
