### PR TITLE
PassType was opposite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-Utils/python/__init__.py
+*__init__.py
 data
 *_LinkDefDict.*
 *_ReflexDict.*

--- a/Mods/src/MuonIdMod.cc
+++ b/Mods/src/MuonIdMod.cc
@@ -23,7 +23,7 @@ mithep::MuonIdMod::IsGood(mithep::Muon const& muon)
   fCutFlow->Fill(cAll);
 
   // Using bool PassClass
-  if (MuonTools::PassClass(&muon, MuonTools::EMuClassType(fMuonClassType)))
+  if (!MuonTools::PassClass(&muon, MuonTools::EMuClassType(fMuonClassType)))
     return false;
 
   fCutFlow->Fill(cMuonClass);


### PR DESCRIPTION
MuonIdMod was failing a muon when it was _passing_ the type identification.
