### PR TITLE
minor improvements on IdMod and SepPUMod

### DIFF
--- a/Mods/interface/IdMod.h
+++ b/Mods/interface/IdMod.h
@@ -38,7 +38,7 @@ namespace mithep {
     ~IdMod();
 
     char const* GetInputName() const { return fInputName; }
-    char const* GetOutputName() const;
+    char const* GetOutputName() const { return fOutputName; }
 
     char const* GetTriggerObjectsName() const       { return fAuxInputNames[kTrigObjects]; }
     char const* GetConversionsName() const          { return fAuxInputNames[kConversions]; }
@@ -58,7 +58,7 @@ namespace mithep {
     Double_t GetEtaMax() const { return fEtaMax; }
 
     void SetInputName(char const* n) { fInputName = n; }
-    void SetOutputName(char const* n);
+    void SetOutputName(char const* n) { fOutputName = n; }
 
     void SetTriggerObjectsName(const char* n)       { fAuxInputNames[kTrigObjects] = n; }
     void SetConversionsName(const char* n)          { fAuxInputNames[kConversions] = n; }
@@ -134,6 +134,7 @@ namespace mithep {
     TH1D* fCutFlow = 0;
 
     TString        fInputName = ""; // input collection of objects to be Id'ed
+    TString        fOutputName = ""; // input collection of objects to be Id'ed
     TString        fAuxInputNames[nAuxInputs] = {};
     TObject const* fAuxInputs[nAuxInputs] = {};
 
@@ -167,34 +168,16 @@ namespace mithep {
   }
 
   template<class O>
-  char const*
-  mithep::IdMod<O>::GetOutputName() const
-  {
-    if (fIsFilterMode)
-      return fGoodObjects.GetName();
-    else
-      return fFlags.GetName();
-  }
-
-  template<class O>
-  void
-  mithep::IdMod<O>::SetOutputName(char const* n)
-  {
-    if (fIsFilterMode)
-      return fGoodObjects.SetName(n);
-    else
-      return fFlags.SetName(n);
-  }
-
-  template<class O>
   void
   mithep::IdMod<O>::SlaveBegin()
   {
     if (fIsFilterMode) {
+      fGoodObjects.SetName(fOutputName);
       if (!PublishObj(&fGoodObjects))
         SendError(kAbortAnalysis, "SlaveBegin", "Cannot publish output");
     }
     else {
+      fFlags.SetName(fOutputName);
       if (!PublishObj(&fFlags))
         SendError(kAbortAnalysis, "SlaveBegin", "Cannot publish output");
     }

--- a/Mods/interface/SeparatePileUpMod.h
+++ b/Mods/interface/SeparatePileUpMod.h
@@ -10,8 +10,6 @@
 #define MITPHYSICS_MODS_SEPARATEPILEUPMOD_H
 
 #include "MitAna/TreeMod/interface/BaseMod.h" 
-#include "MitAna/DataTree/interface/VertexFwd.h"
-#include "MitAna/DataTree/interface/PFCandidateFwd.h"
 
 namespace mithep 
 {
@@ -19,26 +17,34 @@ namespace mithep
   {
     public:
       SeparatePileUpMod(const char *name="SeparatePileUpMod", 
-               const char *title="PFNoPU identification module");
+                        const char *title="PFNoPU identification module");
 
-      void                SetPFCandidatesName(const char *n)    { fPFCandidatesName  = n;  }  
-      void                SetPFPileUpName(const char *n)	{ fPFPileUpName  = n;      }  
-      void                SetPFNoPileUpName(const char *n)	{ fPFNoPileUpName  = n;    }  
-      void                SetAllVertexName(const char *n)       { fAllVertexName = n;      }
-      void                SetVertexName(const char *n)          { fVertexName = n;         }
-      void                SetCheckClosestZVertex(Bool_t b)      { fCheckClosestZVertex = b;}
-      void                SetUseAllVerteces(Bool_t b)           { fUseAllVertices = b;     }
+      char const* GetPFCandidatesName() const    { return fPFCandidatesName; }  
+      char const* GetPFPileUpName() const        { return fPFPileUpName; }  
+      char const* GetPFNoPileUpName() const      { return fPFNoPileUpName; }  
+      char const* GetAllVertexName() const       { return fAllVertexName; }
+      char const* GetVertexName() const          { return fVertexName; }
+      Bool_t      GetCheckClosestZVertex() const { return fCheckClosestZVertex; }
+      Bool_t      GetUseAllVerteces() const      { return fUseAllVertices; }
+
+      void SetPFCandidatesName(const char *n) { fPFCandidatesName = n; }  
+      void SetPFPileUpName(const char *n)     { fPFPileUpName = n; }  
+      void SetPFNoPileUpName(const char *n)   { fPFNoPileUpName = n; }
+      void SetAllVertexName(const char *n)    { fAllVertexName = n; }
+      void SetVertexName(const char *n)       { fVertexName = n; }
+      void SetCheckClosestZVertex(Bool_t b)   { fCheckClosestZVertex = b; }
+      void SetUseAllVerteces(Bool_t b)        { fUseAllVertices = b; }
 
     protected:
-      void                Process();
+      void Process() override;
 
-      TString               fPFCandidatesName;    //name of PF collection (input)
-      TString               fPFPileUpName;        //name of exported PFPileUp collection (output)
-      TString               fPFNoPileUpName;      //name of exported PFNoPileUp collection (output)
-      TString               fAllVertexName;	  //name of all vertex collection
-      TString               fVertexName;	  //name of good vertex collection
-      Bool_t                fCheckClosestZVertex; //boolean to use the closest vertex approach
-      Bool_t                fUseAllVertices;      //boolean to use all vertices
+      TString fPFCandidatesName;    //name of PF collection (input)
+      TString fPFPileUpName;        //name of exported PFPileUp collection (output)
+      TString fPFNoPileUpName;      //name of exported PFNoPileUp collection (output)
+      TString fAllVertexName;       //name of all vertex collection
+      TString fVertexName;          //name of good vertex collection
+      Bool_t  fCheckClosestZVertex; //boolean to use the closest vertex approach
+      Bool_t  fUseAllVertices;      //boolean to use all vertices
 
     ClassDef(SeparatePileUpMod, 1) // PFNoPU identification module
   };


### PR DESCRIPTION
We were being echonomical with IdMod output name, but this caused dependencies in the order of SetIsFilterMode and SetOutputName. We could either set both output array and bitmask names at the same time or add a member variable for the name. Chose the latter.

Added Get accessors to SeparatePileUpMod. Now you can pass around output (PFPU and PFNoPU) names to subsequent modules.
