### PR TITLE
moving MonoJetAnalysisMod from MitMonoJet

### DIFF
--- a/Skim/dict/MitPhysicsSkimLinkDef.h
+++ b/Skim/dict/MitPhysicsSkimLinkDef.h
@@ -1,5 +1,3 @@
-// $Id: MitPhysicsSkimLinkDef.h,v 1.2 2012/06/03 20:25:56 paus Exp $
-
 #ifndef MITPHYSICS_SKIM_LINKDEF_H
 #define MITPHYSICS_SKIM_LINKDEF_H
 #include "MitPhysics/Skim/interface/BaseH4lSkim.h"
@@ -8,6 +6,7 @@
 #include "MitPhysics/Skim/interface/H4lMuTagProbeSkim.h"
 #include "MitPhysics/Skim/interface/H4lZPlusFakeSkim.h"
 #include "MitPhysics/Skim/interface/H4lLightFlavorSkim.h"
+#include "MitPhysics/Skim/interface/MonoJetAnalysisMod.h"
 #endif
 
 #ifdef __CLING__
@@ -23,4 +22,5 @@
 #pragma link C++ class mithep::H4lMuTagProbeSkim+;
 #pragma link C++ class mithep::H4lZPlusFakeSkim+;
 #pragma link C++ class mithep::H4lLightFlavorSkim+;
+#pragma link C++ class mithep::MonoJetAnalysisMod+;
 #endif

--- a/Skim/interface/MonoJetAnalysisMod.h
+++ b/Skim/interface/MonoJetAnalysisMod.h
@@ -1,0 +1,126 @@
+//--------------------------------------------------------------------------------------------------
+// MonoJetAnalysisMod
+//
+// An analysis module for selecting signal and calibration regions for the MonoJet analysis
+// and produces some basic distributions.
+//
+// Authors: LDM, TJW, YI
+//--------------------------------------------------------------------------------------------------
+#ifndef MITPHYSICS_SKIM_MONOJETANALYSISMOD_H
+#define MITPHYSICS_SKIM_MONOJETANALYSISMOD_H
+
+#include "MitAna/TreeMod/interface/BaseMod.h" 
+#include "MitAna/DataCont/interface/Types.h"
+#include "MitAna/DataTree/interface/Names.h"
+#include "MitPhysics/Init/interface/ModNames.h"
+
+#include "TString.h"
+#include "TH1D.h"
+
+namespace mithep {
+
+  class MonoJetAnalysisMod : public BaseMod {
+  public:
+    MonoJetAnalysisMod(const char *name  = "MonoJetAnalysisMod", 
+                       const char *title = "MoneJet Slection Module");
+    ~MonoJetAnalysisMod() {}
+
+    char const* GetCategoryFlagsName() const { return fCategoryFlags.GetName(); }
+    
+    // set input names
+    void SetMetName(const char *n)           { fMetName= n; }
+    void SetJetsName(const char *n)          { fJetsName = n; } 
+    void SetVetoElectronsName(const char *n) { fVetoElectronsName = n; }
+    void SetElectronMaskName(const char *n)  { fElectronMaskName = n; }
+    void SetVetoMuonsName(const char *n)     { fVetoMuonsName = n; }
+    void SetMuonMaskName(const char *n)      { fMuonMaskName = n; }
+    void SetVetoTausName(const char *n)      { fVetoTausName = n; }
+    void SetVetoPhotonsName(const char *n)   { fVetoPhotonsName = n; }
+    void SetPhotonMaskName(const char *n)    { fPhotonMaskName = n; }
+
+    // set output name
+    void SetCategoryFlagsName(const char *n) { fCategoryFlags.SetName(n); }
+
+    // Setting cut values
+    void SetCategoryActive(UInt_t c, Bool_t a = kTRUE) { fCategoryActive[c] = a; }
+    void SetMaxNumJets(UInt_t c, Int_t n)              { fMaxNumJets[c] = n; }
+    void SetMinLeadJetPt(UInt_t c, Double_t x)         { fMinLeadJetPt[c] = x; }
+    void SetMaxJetEta(UInt_t c, Double_t x)            { fMaxJetEta[c] = x; }
+    void SetMinMetPt(UInt_t c, Double_t x)             { fMinMetPt[c] = x; }
+    void SetMinChargedHadronFrac(UInt_t c, Double_t x) { fMinChargedHadronFrac[c] = x; }
+    void SetMaxNeutralHadronFrac(UInt_t c, Double_t x) { fMaxNeutralHadronFrac[c] = x; }
+    void SetMaxNeutralEmFrac(UInt_t c, Double_t x)     { fMaxNeutralEmFrac[c] = x; }
+
+    enum MonoJetCategory {
+      kSignal,
+      kDielectron,
+      kDimuon,
+      kSingleElectron,
+      kSingleMuon,
+      kPhoton,
+      nMonoJetCategories
+    };
+
+    static TString fgMonoJetCategories[nMonoJetCategories];
+
+  protected:
+    // Standard module methods
+    void Process() override;
+    void SlaveBegin() override;
+    void SlaveTerminate() override;
+
+    // names of the input collections
+    TString fMetName{"PFType1CorrectedMet"};
+    TString fJetsName{ModNames::gkCleanJetsName};
+    TString fVetoElectronsName{"VetoElectrons"};
+    TString fElectronMaskName{"GoodElectrons"};
+    TString fVetoMuonsName{"VetoMuons"};
+    TString fMuonMaskName{"GoodMuons"};
+    TString fVetoTausName{"GoodTaus"};
+    TString fVetoPhotonsName{"VetoPhotons"};
+    TString fPhotonMaskName{"GoodPhotons"};
+
+    // Cuts
+    // The module can define up to nCat set of cuts, each corresponing
+    // to a skim category.
+    // Pretty bad implementation as the output file does not document
+    // what cuts resulted in which cateogry, but this is just an example..
+    Bool_t   fCategoryActive[nMonoJetCategories] = {};
+    UInt_t   fMaxNumJets[nMonoJetCategories] = {};
+    Double_t fMinLeadJetPt[nMonoJetCategories] = {};
+    Double_t fMaxJetEta[nMonoJetCategories] = {};
+    Double_t fMinMetPt[nMonoJetCategories] = {};
+    Double_t fMinChargedHadronFrac[nMonoJetCategories] = {};
+    Double_t fMaxNeutralHadronFrac[nMonoJetCategories] = {};
+    Double_t fMaxNeutralEmFrac[nMonoJetCategories] = {};
+
+    // Category (signal/calibration regions) bitmask
+    mithep::NFArrBool fCategoryFlags{nMonoJetCategories, "MonoJetCategories"};
+    
+    // Counters
+    Int_t fNEventsSelected = 0;
+
+    // Histograms
+    TH1D* fCutflow[nMonoJetCategories] = {};   // tally of events passing various cuts
+    TH1D* fRealMetPt[nMonoJetCategories] = {}; // met spectrum
+    TH1D* fMetPt[nMonoJetCategories] = {};     // met spectrum
+    TH1D* fJetPt[nMonoJetCategories] = {};     // jet Pt spectrum
+    TH1D* fJetEta[nMonoJetCategories] = {};    // jet eta
+
+    enum Cut {
+      cAll,
+      cNElectrons,
+      cNMuons,
+      cNTaus,
+      cNPhotons,
+      cLeadJet,
+      cNJets,
+      cMet,
+      nCuts
+    };
+    
+    ClassDef(MonoJetAnalysisMod,1) // MonJet Selection Module
+  };
+
+}
+#endif

--- a/Skim/macros/runMonoJetSkim.C
+++ b/Skim/macros/runMonoJetSkim.C
@@ -1,70 +1,61 @@
-// $Id: runH4lSkim.C,v 1.1 2012/06/02 20:46:24 paus Exp $
-#if !defined(__CLING__) || defined(__ROOTCLING__)
-#include <TSystem.h>
-#include "MitAna/DataUtil/interface/Dbug.h"
-#include "MitAna/DataTree/interface/Names.h"
+#if !defined(__CINT__) || defined(__MAKECINT__)
+#include "MitAna/DataUtil/interface/Debug.h"
 #include "MitAna/Catalog/interface/Catalog.h"
 #include "MitAna/TreeMod/interface/Analysis.h"
 #include "MitAna/TreeMod/interface/OutputMod.h"
 #include "MitAna/TreeMod/interface/HLTMod.h"
-#include "MitAna/DataTree/interface/JetCol.h"
-#include "MitAna/DataTree/interface/PFJetCol.h"
-#include "MitAna/PhysicsMod/interface/MCProcessSelectionMod.h"
 #include "MitAna/PhysicsMod/interface/RunLumiSelectionMod.h"
-#include "MitAna/PhysicsMod/interface/PublisherMod.h"
-#include "MitPhysics/Init/interface/ModNames.h"
 #include "MitPhysics/Mods/interface/GeneratorMod.h"
 #include "MitPhysics/Mods/interface/GoodPVFilterMod.h"
 #include "MitPhysics/Mods/interface/SeparatePileUpMod.h"
-#include "MitPhysics/Mods/interface/MuonIDMod.h"
-#include "MitPhysics/Mods/interface/ElectronIDMod.h"
-#include "MitPhysics/Mods/interface/PhotonIDMod.h"
-#include "MitPhysics/Mods/interface/PFTauIDMod.h"
-#include "MitPhysics/Mods/interface/JetIDMod.h"
-#include "MitPhysics/Mods/interface/ElectronCleaningMod.h"
-#include "MitPhysics/Mods/interface/PhotonCleaningMod.h"
-#include "MitPhysics/Mods/interface/PFTauCleaningMod.h"
-#include "MitPhysics/Mods/interface/JetCleaningMod.h"
-#include "MitPhysics/Mods/interface/MergeLeptonsMod.h"
+#include "MitPhysics/Mods/interface/MuonIdMod.h"
+#include "MitPhysics/Utils/interface/MuonTools.h"
+#include "MitPhysics/Mods/interface/ElectronIdMod.h"
+#include "MitPhysics/Utils/interface/ElectronTools.h"
+#include "MitPhysics/Mods/interface/PhotonIdMod.h"
+#include "MitPhysics/Mods/interface/PFTauIdMod.h"
+#include "MitPhysics/Mods/interface/JetIdMod.h"
 #include "MitPhysics/Mods/interface/JetCorrectionMod.h"
 #include "MitPhysics/Mods/interface/MetCorrectionMod.h"
-#include "MitPhysics/Mods/interface/PhotonMvaMod.h"
-#include "MitPhysics/Mods/interface/MVASystematicsMod.h"
-#include "MitPhysics/Mods/interface/PhotonPairSelector.h"
-#include "MitPhysics/Mods/interface/PhotonTreeWriter.h"
-#include "MitMonoJet/SelMods/interface/MonoJetAnalysisMod.h"
-#include "MitMonoJet/Mods/interface/MonoJetTreeWriter.h"
+#include "MitPhysics/Skim/interface/MonoJetAnalysisMod.h"
+
+#include "TSystem.h"
+
+#include <iostream>
 #endif
 
 using namespace mithep;
 
-int  decodeEnv(char* json, char* overlap, float overlapCut, char* path);
-
 //--------------------------------------------------------------------------------------------------
 void runMonoJetSkim(const char *fileset    = "0000",
 		    const char *skim       = "noskim",
-		    const char *dataset    = "r12a-met-j22-v1",
-		    const char *book       = "t2mit/filefi/032",
+		    const char *dataset    = "WJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8+RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1+AODSIM",
+		    const char *book       = "t2mit/filefi/041",
 		    const char *catalogDir = "/home/cmsprod/catalog",
-		    const char *outputName = "monojet",
+		    const char *outputLabel = "monojet",
 		    int         nEvents    = 1000)
 {
   //------------------------------------------------------------------------------------------------
-  // some parameters get passed through the environment
+  // json parameters get passed through the environment
+  // for MC, the value must be "~"
   //------------------------------------------------------------------------------------------------
-  char json[1024], overlap[1024], path[1024];
-  float overlapCut = -1;
-
-  if (decodeEnv(json,overlap,overlapCut,path) != 0)
+  TString json(gSystem->Getenv("MIT_PROD_JSON"));
+  if (json.Length() == 0) {
+    printf(" JSON file was not properly defined. EXIT!\n");
     return;
+  }
 
-  TString jsonFile = TString("/home/cmsprod/cms/json/") + TString(json);
-  Bool_t  isData   = (jsonFile.CompareTo("/home/cmsprod/cms/json/~") != 0);
+  TString jsonFile = TString("/home/cmsprod/cms/json/") + json;
+  Bool_t  isData   = (json != "~");
+
+  TString MitData(gSystem->Getenv("MIT_DATA"));
+  if(MitData.Length() == 0){
+    MitData = gSystem->Getenv("CMSSW_BASE");
+    MitData += "/src/MitPhysics/data";
+  }
 
   printf("\n Initialization worked: \n\n");
-  printf("   JSON   : %s (file: %s)\n",  json,jsonFile.Data());
-  printf("   OVERLAP: %s\n\n",overlap);
-  printf("   PATH   : %s\n",  path);
+  printf("   JSON   : %s (file: %s)\n",  json.Data(), jsonFile.Data());
   printf("   isData : %d\n\n",isData);
 
   //------------------------------------------------------------------------------------------------
@@ -77,6 +68,8 @@ void runMonoJetSkim(const char *fileset    = "0000",
   //------------------------------------------------------------------------------------------------
   // set up information
   //------------------------------------------------------------------------------------------------
+  std::vector<mithep::BaseMod*> modules;
+
   RunLumiSelectionMod *runLumiSel = new RunLumiSelectionMod;
   runLumiSel->SetAcceptMC(kTRUE);                          // Monte Carlo events are always accepted
 
@@ -92,71 +85,48 @@ void runMonoJetSkim(const char *fileset    = "0000",
   }
   printf("\n Run lumi worked. \n\n");
 
+  modules.push_back(runLumiSel);
+
   // Generator info
-  GeneratorMod *generatorMod = new GeneratorMod;
-  generatorMod->SetPrintDebug(kFALSE);
-  generatorMod->SetPtLeptonMin(0.0);
-  generatorMod->SetEtaLeptonMax(2.7);
-  generatorMod->SetPtPhotonMin(0.0);
-  generatorMod->SetEtaPhotonMax(2.7);
-  generatorMod->SetPtRadPhotonMin(0.0);
-  generatorMod->SetEtaRadPhotonMax(2.7);
-  generatorMod->SetIsData(isData);
-  generatorMod->SetFillHist(! isData);
-  generatorMod->SetApplyISRFilter(kFALSE);
-  generatorMod->SetApplyVVFilter(kFALSE);
-  generatorMod->SetApplyVGFilter(kFALSE);
-  generatorMod->SetFilterBTEvents(kFALSE);
+  GeneratorMod *generatorMod = 0;
+  if (!isData) {
+    generatorMod = new GeneratorMod;
+    generatorMod->SetPrintDebug(kFALSE);
+    generatorMod->SetPtLeptonMin(0.0);
+    generatorMod->SetEtaLeptonMax(2.7);
+    generatorMod->SetPtPhotonMin(0.0);
+    generatorMod->SetEtaPhotonMax(2.7);
+    generatorMod->SetPtRadPhotonMin(0.0);
+    generatorMod->SetEtaRadPhotonMax(2.7);
+    generatorMod->SetIsData(isData);
+    generatorMod->SetFillHist(! isData);
+    generatorMod->SetApplyISRFilter(kFALSE);
+    generatorMod->SetApplyVVFilter(kFALSE);
+    generatorMod->SetApplyVGFilter(kFALSE);
+    generatorMod->SetFilterBTEvents(kFALSE);
+
+    modules.push_back(generatorMod);
+  }
 
   //-----------------------------------------------------------------------------------------------------------
   // HLT information : trigger not applied (neither for data nor for MC, store info to apply selection offline
   //-----------------------------------------------------------------------------------------------------------
-  HLTMod *hltModP = new HLTMod("HLTModP");
+  HLTMod *hltMod = new HLTMod("HLTModP");
 
   // monojet triggers
-  const int nMjtTrigs = 12;
-  TString monoJetTriggers[nMjtTrigs] = { "HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95_v4",
-					 "HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95_v3",
-					 "HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95_v1",
-					 "HLT_MonoCentralPFJet80_PFMETnoMu95_NHEF0p95_v5",
-					 "HLT_MonoCentralPFJet80_PFMETnoMu95_NHEF0p95_v4",
-					 "HLT_MonoCentralPFJet80_PFMETnoMu95_NHEF0p95_v3",
-					 "HLT_MonoCentralPFJet80_PFMETnoMu95_NHEF0p95_v2",
-					 "HLT_MET120_HBHENoiseCleaned_v6",
-					 "HLT_MET120_HBHENoiseCleaned_v5",
-					 "HLT_MET120_HBHENoiseCleaned_v4",
-					 "HLT_MET120_HBHENoiseCleaned_v3",
-					 "HLT_MET120_HBHENoiseCleaned_v2" };
-
+  const int nMjtTrigs = 2;
+  TString monoJetTriggers[nMjtTrigs] = {"HLT_PFMETNoMu120_NoiseCleaned_PFMHTNoMu120_IDTight_v1",
+					"HLT_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v1"};
   for (int i=0; i<nMjtTrigs; i++)
-    hltModP->AddTrigger(TString("!+"+monoJetTriggers[i]),0,999999);
+    hltMod->AddTrigger(TString("!+"+monoJetTriggers[i]),0,999999);
 
-  // VBF triggers
-  const int nVbfTrigs = 7;
-  TString vbfTriggers[nVbfTrigs] = { "HLT_DiPFJet40_PFMETnoMu65_MJJ800VBF_AllJets_v9",
-				     "HLT_DiPFJet40_PFMETnoMu65_MJJ800VBF_AllJets_v8",
-				     "HLT_DiPFJet40_PFMETnoMu65_MJJ800VBF_AllJets_v6",
-				     "HLT_DiPFJet40_PFMETnoMu65_MJJ800VBF_AllJets_v5",
-				     "HLT_DiPFJet40_PFMETnoMu65_MJJ800VBF_AllJets_v4",
-				     "HLT_DiPFJet40_PFMETnoMu65_MJJ800VBF_AllJets_v3",
-				     "HLT_DiPFJet40_PFMETnoMu65_MJJ800VBF_AllJets_v2" };
+  hltMod->SetBitsName("HLTBits");
+  hltMod->SetTrigObjsName("MyHltPhotObjs");
+  hltMod->SetAbortIfNotAccepted(isData);
+  //  hltMod->SetPrintTable(kTRUE);
 
-  for (int i=0; i<nVbfTrigs; i++)
-    hltModP->AddTrigger((TString("!+")+vbfTriggers[i]).Data(),0,999999);
+  modules.push_back(hltMod);
 
-  hltModP->SetBitsName("HLTBits");
-  hltModP->SetTrigObjsName("MyHltPhotObjs");
-  hltModP->SetAbortIfNotAccepted(isData);
-  hltModP->SetPrintTable(kFALSE);
-
-  //------------------------------------------------------------------------------------------------
-  // split pfcandidates to PFPU and PFnoPU
-  //------------------------------------------------------------------------------------------------
-  SeparatePileUpMod* SepPUMod = new SeparatePileUpMod;
-  SepPUMod->SetPFNoPileUpName("pfnopileupcands");
-  SepPUMod->SetPFPileUpName("pfpileupcands");
-  SepPUMod->SetCheckClosestZVertex(kFALSE);
-  
   //------------------------------------------------------------------------------------------------
   // select events with a good primary vertex
   //------------------------------------------------------------------------------------------------
@@ -167,148 +137,121 @@ void runMonoJetSkim(const char *fileset    = "0000",
   goodPvMod->SetMaxRho(2.0);
   goodPvMod->SetIsMC(!isData);
   goodPvMod->SetVertexesName("PrimaryVertexes");
-  
-  //------------------------------------------------------------------------------------------------
-  // object id and cleaning sequence
-  //------------------------------------------------------------------------------------------------
 
+  modules.push_back(goodPvMod);
+
+  //------------------------------------------------------------------------------------------------
+  // split pfcandidates to PFPU and PFnoPU
+  //------------------------------------------------------------------------------------------------
+  SeparatePileUpMod* SepPUMod = new SeparatePileUpMod;
+  SepPUMod->SetPFNoPileUpName("pfnopileupcands");
+  SepPUMod->SetPFPileUpName("pfpileupcands");
+  SepPUMod->SetCheckClosestZVertex(kFALSE);
+
+  modules.push_back(SepPUMod);
+ 
   //-----------------------------------
   // Lepton Selection 
   //-----------------------------------
-  ElectronIDMod* eleIdMod = new ElectronIDMod;
-  eleIdMod->SetPtMin(10.);  
-  eleIdMod->SetEtaMax(2.5);
+  MuonIdMod *vetoMuonIdMod = new MuonIdMod("VetoMuonId");
+  vetoMuonIdMod->SetMuonClassType(mithep::MuonTools::kPFGlobalorTracker);
+  vetoMuonIdMod->SetIdType(mithep::MuonTools::kNoId);
+  vetoMuonIdMod->SetPFNoPileupCandidatesName(SepPUMod->GetPFNoPileUpName());
+  vetoMuonIdMod->SetPFPileupCandidatesName(SepPUMod->GetPFPileUpName());
+  vetoMuonIdMod->SetIsoType(mithep::MuonTools::kPFIsoBetaPUCorrected);
+  vetoMuonIdMod->SetApplyD0Cut(kTRUE);
+  vetoMuonIdMod->SetApplyDZCut(kTRUE);
+  vetoMuonIdMod->SetWhichVertex(0);
+  vetoMuonIdMod->SetPtMin(10.);
+  vetoMuonIdMod->SetEtaMax(2.4);
+  vetoMuonIdMod->SetOutputName("VetoMuons");
+
+  modules.push_back(vetoMuonIdMod);
+
+  MuonIdMod *muonIdMod = new MuonIdMod("GoodMuonId");
+  muonIdMod->SetInputName(vetoMuonIdMod->GetOutputName());
+  muonIdMod->SetMuonClassType(mithep::MuonTools::kPFGlobalorTracker);
+  muonIdMod->SetIdType(mithep::MuonTools::kMuonPOG2012CutBasedIdTight);
+  muonIdMod->SetPFNoPileupCandidatesName(SepPUMod->GetPFNoPileUpName());
+  muonIdMod->SetPFPileupCandidatesName(SepPUMod->GetPFPileUpName());
+  muonIdMod->SetIsoType(mithep::MuonTools::kPFIsoBetaPUCorrectedTight);
+  muonIdMod->SetApplyD0Cut(kTRUE);
+  muonIdMod->SetApplyDZCut(kTRUE);
+  muonIdMod->SetWhichVertex(0);
+  muonIdMod->SetPtMin(20.);
+  muonIdMod->SetEtaMax(2.4);
+  muonIdMod->SetIsFilterMode(kFALSE);
+  muonIdMod->SetOutputName("GoodMuons");
+
+  modules.push_back(muonIdMod);
+
+  ElectronIdMod* vetoEleIdMod = new ElectronIdMod("VetoElectronId");
+  vetoEleIdMod->SetPtMin(10.);  
+  vetoEleIdMod->SetEtaMax(2.4);
+  vetoEleIdMod->SetApplyEcalFiducial(true);
+  vetoEleIdMod->SetIdType(mithep::ElectronTools::kPhys14Veto);
+  vetoEleIdMod->SetIsoType(mithep::ElectronTools::kPhys14VetoIso);
+  vetoEleIdMod->SetConversionsName("Conversions");
+  vetoEleIdMod->SetApplyConversionFilterType1(kTRUE);
+  vetoEleIdMod->SetApplyConversionFilterType2(kFALSE);
+  vetoEleIdMod->SetApplyD0Cut(kTRUE);
+  vetoEleIdMod->SetApplyDZCut(kTRUE);
+  vetoEleIdMod->SetWhichVertex(0);
+  vetoEleIdMod->SetOutputName("VetoElectrons");
+
+  modules.push_back(vetoEleIdMod);
+
+  ElectronIdMod* eleIdMod = new ElectronIdMod("GoodElectronId");
+  eleIdMod->SetInputName(vetoEleIdMod->GetOutputName());
+  eleIdMod->SetPtMin(20.);
+  eleIdMod->SetEtaMax(2.4);
   eleIdMod->SetApplyEcalFiducial(true);
-  eleIdMod->SetIDType("VBTFWorkingPoint95Id");  
-  eleIdMod->SetIsoType("PFIso");
+  eleIdMod->SetIdType(mithep::ElectronTools::kPhys14Medium);
+  eleIdMod->SetIsoType(mithep::ElectronTools::kPhys14MediumIso);
+  eleIdMod->SetConversionsName("Conversions");
   eleIdMod->SetApplyConversionFilterType1(kTRUE);
   eleIdMod->SetApplyConversionFilterType2(kFALSE);
-  eleIdMod->SetChargeFilter(kFALSE);
   eleIdMod->SetApplyD0Cut(kTRUE);
   eleIdMod->SetApplyDZCut(kTRUE);
-  eleIdMod->SetWhichVertex(-1);
-  eleIdMod->SetNExpectedHitsInnerCut(0);  
-  eleIdMod->SetGoodElectronsName("GoodElectronsBS");
-  eleIdMod->SetRhoType(RhoUtilities::CMS_RHO_RHOKT6PFJETS); 
+  eleIdMod->SetWhichVertex(0);
+  eleIdMod->SetIsFilterMode(kFALSE);
+  eleIdMod->SetOutputName("GoodElectrons");
 
-  MuonIDMod* muonIdGG = new MuonIDMod;
-  // base kinematics
-  muonIdGG->SetPtMin(10.);
-  muonIdGG->SetEtaCut(2.4);
-  // base ID
-  muonIdGG->SetIDType("NoId");
-  muonIdGG->SetClassType("GlobalorTracker");
-  muonIdGG->SetWhichVertex(-1); // this is a 'hack'.. but hopefully good enough...
-  muonIdGG->SetD0Cut(0.02);
-  muonIdGG->SetDZCut(0.5);
-  muonIdGG->SetIsoType("PFIsoBetaPUCorrected"); //h
-  muonIdGG->SetPFIsoCut(0.2); //h
-  muonIdGG->SetOutputName("HggLeptonTagMuons");
-  muonIdGG->SetPFNoPileUpName("pfnopileupcands");
-  muonIdGG->SetPFPileUpName("pfpileupcands");
-  muonIdGG->SetPVName(Names::gkPVBeamSpotBrn); 
-
-  MuonIDMod *muonIdWW = new MuonIDMod;
-  muonIdWW->SetOutputName("HWWMuons");
-  muonIdWW->SetIntRadius(0.0);
-  muonIdWW->SetClassType("GlobalTracker");
-  muonIdWW->SetIDType("WWMuIdV4");
-  muonIdWW->SetIsoType("IsoRingsV0_BDTG_Iso");
-  muonIdWW->SetApplyD0Cut(kTRUE);
-  muonIdWW->SetApplyDZCut(kTRUE);
-  muonIdWW->SetWhichVertex(0);
-  muonIdWW->SetRhoType(RhoUtilities::CMS_RHO_RHOKT6PFJETS);
-  muonIdWW->SetPtMin(10.);
-  muonIdWW->SetEtaCut(2.4);
-
-  MuonIDMod *muonId = muonIdWW;   //MuonIDMod *muonId = muonIdGG;
-  
-  ElectronCleaningMod *electronCleaning = new ElectronCleaningMod;
-  electronCleaning->SetCleanMuonsName(muonId->GetOutputName());
-  electronCleaning->SetGoodElectronsName(eleIdMod->GetOutputName());
-  electronCleaning->SetCleanElectronsName("CleanElectrons");
-
-  MergeLeptonsMod *merger = new MergeLeptonsMod;
-  merger->SetMuonsName(muonId->GetOutputName());
-  merger->SetElectronsName(electronCleaning->GetOutputName());
-  merger->SetMergedName("MergedLeptons");
-
-  TString MitData = TString(gSystem->Getenv("CMSSW_BASE")) + TString("/src/MitPhysics/data");
+  modules.push_back(eleIdMod);
 
   //-----------------------------------
-  // Photon Regression + ID 
+  // Photon Id 
   //-----------------------------------
-  PhotonMvaMod *photonReg = new PhotonMvaMod;
-  photonReg->SetRegressionVersion(3);
-  photonReg->SetRegressionWeights((MitData+TString("/gbrv3ph_52x.root")).Data());
-  photonReg->SetOutputName("GoodPhotonsRegr");
-  photonReg->SetApplyShowerRescaling(kTRUE);
-  photonReg->SetMinNumPhotons(0);
-  photonReg->SetIsData(isData);
 
-  PhotonIDMod *photonIDMod = new PhotonIDMod;
-  photonIDMod->SetPtMin(0.0);
-  photonIDMod->SetOutputName("GoodPhotons");
-  photonIDMod->SetIDType("BaseLineCiCPFNoPresel");
-  photonIDMod->SetIsoType("NoIso");
-  photonIDMod->SetApplyElectronVeto(kTRUE);
-  photonIDMod->SetApplyPixelSeed(kTRUE);
-  photonIDMod->SetApplyConversionId(kTRUE);
-  photonIDMod->SetApplyFiduciality(kTRUE);       
-  photonIDMod->SetIsData(isData);
-  photonIDMod->SetPhotonsFromBranch(kFALSE);
-  photonIDMod->SetInputName(photonReg->GetOutputName());
-  //get the photon with regression energy  
-  photonIDMod->DoMCSmear(kTRUE);
-  photonIDMod->DoDataEneCorr(kTRUE);
-  //------------------------------------------Energy smear and scale--------------------------------------------------------------
-  photonIDMod->SetMCSmearFactors2012HCP(0.0111,0.0111,0.0107,0.0107,0.0155,0.0194,0.0295,0.0276,0.037,0.0371);
-  photonIDMod->AddEnCorrPerRun2012HCP(190645,190781,0.9964,0.9964,1.0020,1.0020,0.9893,1.0028,0.9871,0.9937,0.9839,0.9958);
-  photonIDMod->AddEnCorrPerRun2012HCP(190782,191042,1.0024,1.0024,1.0079,1.0079,0.9923,1.0058,0.9911,0.9977,0.9886,1.0005);
-  photonIDMod->AddEnCorrPerRun2012HCP(191043,193555,0.9935,0.9935,0.9991,0.9991,0.9861,0.9997,0.9894,0.9960,0.9864,0.9982);
-  photonIDMod->AddEnCorrPerRun2012HCP(193556,194150,0.9920,0.9920,0.9976,0.9976,0.9814,0.9951,0.9896,0.9962,0.9872,0.9990);
-  photonIDMod->AddEnCorrPerRun2012HCP(194151,194532,0.9925,0.9925,0.9981,0.9981,0.9826,0.9963,0.9914,0.9980,0.9874,0.9993);
-  photonIDMod->AddEnCorrPerRun2012HCP(194533,195113,0.9927,0.9927,0.9983,0.9983,0.9844,0.9981,0.9934,0.9999,0.9878,0.9996);
-  photonIDMod->AddEnCorrPerRun2012HCP(195114,195915,0.9929,0.9929,0.9984,0.9984,0.9838,0.9974,0.9942,1.0007,0.9878,0.9997);
-  photonIDMod->AddEnCorrPerRun2012HCP(195916,198115,0.9919,0.9919,0.9975,0.9975,0.9827,0.9964,0.9952,1.0017,0.9869,0.9987);
-  photonIDMod->AddEnCorrPerRun2012HCP(198116,199803,0.9955,0.9955,1.0011,1.0011,0.9859,0.9995,0.9893,0.9959,0.9923,1.0041);
-  photonIDMod->AddEnCorrPerRun2012HCP(199804,200048,0.9967,0.9967,1.0023,1.0023,0.9870,1.0006,0.9893,0.9959,0.9937,1.0055);
-  photonIDMod->AddEnCorrPerRun2012HCP(200049,200151,0.9980,0.9980,1.0036,1.0036,0.9877,1.0012,0.9910,0.9976,0.9980,1.0097);
-  photonIDMod->AddEnCorrPerRun2012HCP(200152,200490,0.9958,0.9958,1.0013,1.0013,0.9868,1.0004,0.9922,0.9988,0.9948,1.0065);
-  photonIDMod->AddEnCorrPerRun2012HCP(200491,200531,0.9979,0.9979,1.0035,1.0035,0.9876,1.0012,0.9915,0.9981,0.9979,1.0096);
-  photonIDMod->AddEnCorrPerRun2012HCP(200532,201656,0.9961,0.9961,1.0017,1.0017,0.9860,0.9996,0.9904,0.9970,0.9945,1.0063);
-  photonIDMod->AddEnCorrPerRun2012HCP(201657,202305,0.9969,0.9969,1.0025,1.0025,0.9866,1.0002,0.9914,0.9980,0.9999,1.0116);
-  photonIDMod->AddEnCorrPerRun2012HCP(202305,203002,0.9982,0.9982,1.0038,1.0038,0.9872,1.0008,0.9934,1.0000,1.0018,1.0135);
-  photonIDMod->AddEnCorrPerRun2012HCP(203003,203984,1.0006,1.0006,1.0061,1.0061,0.9880,1.0017,0.9919,0.9988,0.9992,1.0104);     
-  photonIDMod->AddEnCorrPerRun2012HCP(203985,205085,0.9993,0.9993,1.0048,1.0048,0.9903,1.0040,0.9928,0.9997,0.9987,1.0099);     
-  photonIDMod->AddEnCorrPerRun2012HCP(205086,205310,1.0004,1.0004,1.0059,1.0059,0.9901,1.0037,0.9987,1.0055,1.0091,1.0202);     
-  photonIDMod->AddEnCorrPerRun2012HCP(205311,206207,1.0000,1.0000,1.0055,1.0055,0.9891,1.0028,0.9948,1.0017,1.0032,1.0144);     
-  photonIDMod->AddEnCorrPerRun2012HCP(206208,206483,1.0003,1.0003,1.0058,1.0058,0.9895,1.0032,0.9921,0.9989,1.0056,1.0167);     
-  photonIDMod->AddEnCorrPerRun2012HCP(206484,206597,1.0005,1.0005,1.0060,1.0060,0.9895,1.0032,0.9968,1.0036,1.0046,1.0158);     
-  photonIDMod->AddEnCorrPerRun2012HCP(206598,206896,1.0006,1.0006,1.0061,1.0061,0.9881,1.0017,0.9913,0.9982,1.0050,1.0162);     
-  photonIDMod->AddEnCorrPerRun2012HCP(206897,207220,1.0006,1.0006,1.0061,1.0061,0.9884,1.0021,0.9909,0.9978,1.0053,1.0165);     
-  photonIDMod->AddEnCorrPerRun2012HCP(207221,208686,1.0006,1.0006,1.0061,1.0061,0.9894,1.0030,0.9951,1.0020,1.0060,1.0172);     
-  //---------------------------------shower shape scale--------------------------------------------------------------------------------
-  photonIDMod->SetDoShowerShapeScaling(kTRUE);
-  photonIDMod->SetShowerShapeType("2012ShowerShape");
-  photonIDMod->Set2012HCP(kTRUE);
+  PhotonIdMod *vetoPhotonIdMod = new PhotonIdMod("VetoPhotonId");
+  vetoPhotonIdMod->SetPtMin(15.);
+  vetoPhotonIdMod->SetOutputName("VetoPhotons");
+  vetoPhotonIdMod->SetIdType(mithep::PhotonTools::kPhys14Loose);
+  vetoPhotonIdMod->SetIsoType(mithep::PhotonTools::kPhys14LooseIso);
+  vetoPhotonIdMod->SetApplyElectronVeto(kTRUE);
 
-  PFTauIDMod *pfTauIDMod = new PFTauIDMod;
-  pfTauIDMod->SetPFTausName("HPSTaus");
-  pfTauIDMod->SetIsLooseId(kFALSE);
+  modules.push_back(vetoPhotonIdMod);
 
-  PhotonCleaningMod *photonCleaningMod = new PhotonCleaningMod;
-  photonCleaningMod->SetCleanElectronsName(electronCleaning->GetOutputName());
-  photonCleaningMod->SetGoodPhotonsName(photonIDMod->GetOutputName());
-  photonCleaningMod->SetCleanPhotonsName("CleanPhotons");
+  PhotonIdMod *photonIdMod = new PhotonIdMod("GoodPhotonId");
+  photonIdMod->SetInputName(vetoPhotonIdMod->GetOutputName());
+  photonIdMod->SetPtMin(90.);
+  photonIdMod->SetOutputName("GoodPhotons");
+  photonIdMod->SetIdType(mithep::PhotonTools::kPhys14Medium);
+  photonIdMod->SetIsoType(mithep::PhotonTools::kPhys14MediumIso);
+  photonIdMod->SetApplyElectronVeto(kTRUE);
+  photonIdMod->SetIsFilterMode(kFALSE);
 
-  PFTauCleaningMod *pfTauCleaningMod = new PFTauCleaningMod;
-  pfTauCleaningMod->SetGoodPFTausName(pfTauIDMod->GetGoodPFTausName());
-  pfTauCleaningMod->SetCleanMuonsName(muonId->GetOutputName());
+  modules.push_back(photonIdMod);
 
-  PublisherMod<PFJet,Jet> *pubJet = new PublisherMod<PFJet,Jet>("JetPub");
-  pubJet->SetInputName("AKt5PFJets");
-  pubJet->SetOutputName("PubAKt5PFJets");
+  PFTauIdMod *pfTauIdMod = new PFTauIdMod;
+  pfTauIdMod->SetPtMin(18.);
+  pfTauIdMod->SetEtaMax(2.3);
+  pfTauIdMod->SetInputName("HPSTaus");
+  pfTauIdMod->AddDiscriminator(mithep::PFTau::kDiscriminationByDecayModeFindingNewDMs);
+  pfTauIdMod->AddCutDiscriminator(mithep::PFTau::kDiscriminationByRawCombinedIsolationDBSumPtCorr3Hits,5);
+  pfTauIdMod->SetOutputName("GoodTaus");
+
+  modules.push_back(pfTauIdMod);
 
   JetCorrectionMod *jetCorr = new JetCorrectionMod;
   if (isData){ 
@@ -318,222 +261,136 @@ void runMonoJetSkim(const char *fileset    = "0000",
     jetCorr->AddCorrectionFromFile((MitData+TString("/Summer13_V1_DATA_L2L3Residual_AK5PF.txt")).Data());
   }                                                                                      
   else {                                                                                 
-    jetCorr->AddCorrectionFromFile((MitData+TString("/Summer13_V1_MC_L1FastJet_AK5PF.txt")).Data()); 
-    jetCorr->AddCorrectionFromFile((MitData+TString("/Summer13_V1_MC_L2Relative_AK5PF.txt")).Data()); 
-    jetCorr->AddCorrectionFromFile((MitData+TString("/Summer13_V1_MC_L3Absolute_AK5PF.txt")).Data()); 
+    jetCorr->AddCorrectionFromFile((MitData+TString("/MCRUN2_74_V9_L1FastJet_AK4PFchs.txt")).Data()); 
+    jetCorr->AddCorrectionFromFile((MitData+TString("/MCRUN2_74_V9_L2Relative_AK4PFchs.txt")).Data()); 
+    jetCorr->AddCorrectionFromFile((MitData+TString("/MCRUN2_74_V9_L3Absolute_AK4PFchs.txt")).Data()); 
   }
-  jetCorr->SetInputName(pubJet->GetOutputName());
+  jetCorr->SetInputName("AKt4PFJetsCHS");
   jetCorr->SetCorrectedName("CorrectedJets");    
 
-  JetIDMod *jetID = new JetIDMod;
-  jetID->SetInputName(jetCorr->GetOutputName());
-  jetID->SetPtCut(30.0);
-  jetID->SetEtaMaxCut(4.7);
-  jetID->SetJetEEMFractionMinCut(0.00);
-  jetID->SetOutputName("GoodJets");
-  jetID->SetApplyBetaCut(kFALSE);
-  jetID->SetApplyMVACut(kTRUE);
+  modules.push_back(jetCorr);
 
-  JetCleaningMod *jetCleaning = new JetCleaningMod;
-  jetCleaning->SetCleanElectronsName(electronCleaning->GetOutputName());
-  jetCleaning->SetCleanMuonsName(muonId->GetOutputName());
-  jetCleaning->SetCleanPhotonsName(photonCleaningMod->GetOutputName());
-  jetCleaning->SetApplyPhotonRemoval(kTRUE);
-  jetCleaning->SetGoodJetsName(jetID->GetOutputName());
-  jetCleaning->SetCleanJetsName("CleanJets");
-        
-  MetCorrectionMod *metCorrT0T1Shift = new MetCorrectionMod;
-  metCorrT0T1Shift->SetInputName("PFMet");
-  metCorrT0T1Shift->SetJetsName(pubJet->GetOutputName());    
-  metCorrT0T1Shift->SetCorrectedJetsName(jetCorr->GetOutputName());    
-  metCorrT0T1Shift->SetCorrectedName("PFMetT0T1Shift");   
-  metCorrT0T1Shift->ApplyType0(kTRUE);   
-  metCorrT0T1Shift->ApplyType1(kTRUE);   
-  metCorrT0T1Shift->ApplyShift(kTRUE);   
-  metCorrT0T1Shift->IsData(isData);
-  metCorrT0T1Shift->SetPrint(kFALSE);
+  JetIdMod *jetId = new JetIdMod;
+  jetId->SetInputName(jetCorr->GetOutputName());
+  jetId->SetOutputName("GoodJets");
+  jetId->SetPtMin(30.0);
+  jetId->SetEtaMax(2.5);
+  jetId->SetApplyPFLooseId(kTRUE);
+  jetId->SetMVATrainingSet(JetIDMVA::k53BDTCHSFullPlusRMS);
+  jetId->SetMVACutWP(JetIDMVA::kLoose);
+  jetId->SetMVACutsFile(MitData + "/jetIDCuts_121221.dat");
+  jetId->SetMVAWeightsFile(MitData + "/TMVAClassification_5x_BDT_chsFullPlusRMS.weights.xml");
+
+  modules.push_back(jetId);
+
+  MetCorrectionMod *type1MetCorr = new MetCorrectionMod;
+  type1MetCorr->SetInputName("PFMet");
+  type1MetCorr->SetOutputName("PFType1CorrectedMet");
+  type1MetCorr->SetJetsName("AKt4PFJets");
+  type1MetCorr->SetRhoAlgo(PileupEnergyDensity::kFixedGridFastjetAll);
+  type1MetCorr->SetMaxEMFraction(0.9);
+  type1MetCorr->SetSkipMuons(kTRUE);
+  type1MetCorr->ApplyType0(kFALSE);
+  type1MetCorr->ApplyType1(kTRUE);
+  type1MetCorr->ApplyShift(kFALSE);
+  type1MetCorr->AddJetCorrectionFromFile(MitData + "/MCRUN2_74_V9_L1FastJet_AK4PF.txt");
+  type1MetCorr->AddJetCorrectionFromFile(MitData + "/MCRUN2_74_V9_L2Relative_AK4PF.txt");
+  type1MetCorr->AddJetCorrectionFromFile(MitData + "/MCRUN2_74_V9_L3Absolute_AK4PF.txt");
+  type1MetCorr->IsData(isData);
+
+  modules.push_back(type1MetCorr);
 
   //------------------------------------------------------------------------------------------------
-  // select events with jet+MET
+  // select events
   //------------------------------------------------------------------------------------------------
-  // VBF
-  float minLeadingJetEt = 40;
+
+  float minLeadingJetPt = 50.;
   float maxJetEta       = 4.7;
-  float minMet          = 0;
+  float minMet          = 50.;
 
-  MonoJetAnalysisMod *jetPlusMet = new MonoJetAnalysisMod("MonoJetSelector");
-  jetPlusMet->SetInputMetName(metCorrT0T1Shift->GetOutputName());
-  jetPlusMet->SetMetFromBranch(kFALSE);
-  jetPlusMet->SetJetsName(jetCleaning->GetOutputName());
-  jetPlusMet->SetJetsFromBranch(kFALSE);
-  jetPlusMet->SetElectronsName(electronCleaning->GetOutputName());
-  jetPlusMet->SetElectronsFromBranch(kFALSE);
-  jetPlusMet->SetMuonsName(muonId->GetOutputName());
-  jetPlusMet->SetMuonsFromBranch(kFALSE);
-  jetPlusMet->SetTausName(pfTauCleaningMod->GetOutputName());
-  jetPlusMet->SetTausFromBranch(kFALSE);
-  jetPlusMet->SetLeptonsName(merger->GetOutputName());
-  jetPlusMet->SetMinNumJets(1);
-  jetPlusMet->SetMinNumLeptons(0);
-  jetPlusMet->SetMinChargedHadronFrac(0.2); 
-  jetPlusMet->SetMaxNeutralHadronFrac(0.7);
-  jetPlusMet->SetMaxNeutralEmFrac(0.7);
-  jetPlusMet->SetMinJetEt(minLeadingJetEt);
-  jetPlusMet->SetMaxJetEta(maxJetEta);
-  jetPlusMet->SetMinMetEt(minMet);
+  MonoJetAnalysisMod *monojetSel = new MonoJetAnalysisMod("MonoJetSelector");
+  monojetSel->SetMetName(type1MetCorr->GetOutputName());
+  monojetSel->SetJetsName(jetId->GetOutputName());
+  monojetSel->SetVetoElectronsName(vetoEleIdMod->GetOutputName());
+  monojetSel->SetElectronMaskName(eleIdMod->GetOutputName());
+  monojetSel->SetVetoMuonsName(vetoMuonIdMod->GetOutputName());
+  monojetSel->SetMuonMaskName(muonIdMod->GetOutputName());
+  monojetSel->SetVetoTausName(pfTauIdMod->GetOutputName());
+  monojetSel->SetVetoPhotonsName(vetoPhotonIdMod->GetOutputName());
+  monojetSel->SetPhotonMaskName(photonIdMod->GetOutputName());
+  monojetSel->SetCategoryFlagsName("MonoJetEventCategories");
 
-  MonoJetAnalysisMod *dilepton = new MonoJetAnalysisMod("MonoJetSelector_dilepton");
-  dilepton->SetInputMetName(metCorrT0T1Shift->GetOutputName());
-  dilepton->SetMetFromBranch(kFALSE);
-  dilepton->SetJetsName(jetCleaning->GetOutputName());
-  dilepton->SetJetsFromBranch(kFALSE);
-  dilepton->SetElectronsName(electronCleaning->GetOutputName());
-  dilepton->SetElectronsFromBranch(kFALSE);
-  dilepton->SetMuonsName(muonId->GetOutputName());
-  dilepton->SetMuonsFromBranch(kFALSE);
-  dilepton->SetTausName(pfTauCleaningMod->GetOutputName());
-  dilepton->SetTausFromBranch(kFALSE);
-  dilepton->SetLeptonsName(merger->GetOutputName());
-  dilepton->SetMinNumJets(1);
-  dilepton->SetMinNumLeptons(2);
-  dilepton->SetMinChargedHadronFrac(0.2);
-  dilepton->SetMaxNeutralHadronFrac(0.7);
-  dilepton->SetMaxNeutralEmFrac(0.7);
-  dilepton->SetMinJetEt(minLeadingJetEt);
-  dilepton->SetMaxJetEta(maxJetEta);
-  dilepton->SetMinMetEt(0);
+  // Using uniform setup for all categories
+  for (unsigned iCat = 0; iCat != MonoJetAnalysisMod::nMonoJetCategories; ++iCat) {
+    monojetSel->SetCategoryActive(iCat, kTRUE);
+    monojetSel->SetMaxNumJets(iCat, 3);
+    monojetSel->SetMinLeadJetPt(iCat, minLeadingJetPt);
+    monojetSel->SetMaxJetEta(iCat, maxJetEta);
+    monojetSel->SetMinMetPt(iCat, minMet);
+    monojetSel->SetMinChargedHadronFrac(iCat, 0.2); 
+    monojetSel->SetMaxNeutralHadronFrac(iCat, 0.7);
+    monojetSel->SetMaxNeutralEmFrac(iCat, 0.7);
+  }
+
+  modules.push_back(monojetSel);
+
+  //------------------------------------------------------------------------------------------------
+  // skim output
+  //------------------------------------------------------------------------------------------------
+  TString outputName = TString(outputLabel);
+  outputName += TString("_") + TString(dataset) + TString("_") + TString(skim);
+  if (TString(fileset) != TString(""))
+    outputName += TString("_") + TString(fileset);
   
-  MonoJetAnalysisMod *wlnu = new MonoJetAnalysisMod("MonoJetSelector_wlnu");
-  wlnu->SetInputMetName(metCorrT0T1Shift->GetOutputName());
-  wlnu->SetMetFromBranch(kFALSE);
-  wlnu->SetJetsName(jetCleaning->GetOutputName());
-  wlnu->SetJetsFromBranch(kFALSE);
-  wlnu->SetElectronsName(electronCleaning->GetOutputName());
-  wlnu->SetElectronsFromBranch(kFALSE);
-  wlnu->SetMuonsName(muonId->GetOutputName());
-  wlnu->SetMuonsFromBranch(kFALSE);
-  wlnu->SetTausName(pfTauCleaningMod->GetOutputName());
-  wlnu->SetTausFromBranch(kFALSE);
-  wlnu->SetLeptonsName(merger->GetOutputName());
-  wlnu->SetMinNumJets(1);
-  wlnu->SetMinNumLeptons(1);
-  wlnu->SetMinChargedHadronFrac(0.2);
-  wlnu->SetMaxNeutralHadronFrac(0.7);
-  wlnu->SetMaxNeutralEmFrac(0.7);
-  wlnu->SetMinJetEt(minLeadingJetEt);
-  wlnu->SetMaxJetEta(maxJetEta);
-  wlnu->SetMinMetEt(0);
+  OutputMod *skimOutput = new OutputMod;
+  skimOutput->Drop("*");
+  skimOutput->Keep("HLT*");
 
-  MonoJetTreeWriter *jetPlusMetTree = new MonoJetTreeWriter("MonoJetTreeWriter");
-  jetPlusMetTree->SetTriggerObjectsName(hltModP->GetOutputName());
-  jetPlusMetTree->SetMetName(metCorrT0T1Shift->GetOutputName());
-  jetPlusMetTree->SetMetFromBranch(kFALSE);
-  jetPlusMetTree->SetPhotonsFromBranch(kFALSE);
-  jetPlusMetTree->SetPhotonsName(photonCleaningMod->GetOutputName());
-  jetPlusMetTree->SetElectronsFromBranch(kFALSE);
-  jetPlusMetTree->SetElectronsName(electronCleaning->GetOutputName());
-  jetPlusMetTree->SetMuonsFromBranch(kFALSE);
-  jetPlusMetTree->SetMuonsName(muonId->GetOutputName());
-  jetPlusMetTree->SetTausFromBranch(kFALSE);
-  jetPlusMetTree->SetTausName(pfTauCleaningMod->GetOutputName());
-  jetPlusMetTree->SetJetsFromBranch(kFALSE);
-  jetPlusMetTree->SetJetsName(jetCleaning->GetOutputName());
-  jetPlusMetTree->SetPVFromBranch(kFALSE);
-  jetPlusMetTree->SetPVName(goodPvMod->GetOutputName());
-  jetPlusMetTree->SetLeptonsName(merger->GetOutputName());
-  jetPlusMetTree->SetIsData(isData);
-  jetPlusMetTree->SetProcessID(0);
-  jetPlusMetTree->SetFillNtupleType(0);
+  skimOutput->Keep("MC*");
+  skimOutput->Keep("PileupInfo");
+  skimOutput->Keep("Rho");
+  skimOutput->Keep("EvtSelData");
+  skimOutput->Keep("BeamSpot");
+  skimOutput->Keep("PrimaryVertexes");
+  skimOutput->Keep("PFMet");
+  skimOutput->Keep("AKt4PFJetsCHS");
+  skimOutput->Keep("AKt8PFJetsCHS");
+  skimOutput->Keep("Electrons");
+  skimOutput->Keep("Muons");
+  skimOutput->Keep("HPSTaus");
+  skimOutput->Keep("Photons");
+  skimOutput->AddNewBranch(monojetSel->GetCategoryFlagsName());
 
-  MonoJetTreeWriter *dileptonTree = new MonoJetTreeWriter("MonoJetTreeWriter_dilepton");
-  dileptonTree->SetTriggerObjectsName(hltModP->GetOutputName());
-  dileptonTree->SetMetName(metCorrT0T1Shift->GetOutputName());
-  dileptonTree->SetMetFromBranch(kFALSE);
-  dileptonTree->SetPhotonsFromBranch(kFALSE);
-  dileptonTree->SetPhotonsName(photonCleaningMod->GetOutputName());
-  dileptonTree->SetElectronsFromBranch(kFALSE);
-  dileptonTree->SetElectronsName(electronCleaning->GetOutputName());
-  dileptonTree->SetMuonsFromBranch(kFALSE);
-  dileptonTree->SetMuonsName(muonId->GetOutputName());
-  dileptonTree->SetTausFromBranch(kFALSE);
-  dileptonTree->SetTausName(pfTauCleaningMod->GetOutputName());
-  dileptonTree->SetJetsFromBranch(kFALSE);
-  dileptonTree->SetJetsName(jetCleaning->GetOutputName());
-  dileptonTree->SetPVFromBranch(kFALSE);
-  dileptonTree->SetPVName(goodPvMod->GetOutputName());
-  dileptonTree->SetLeptonsName(merger->GetOutputName());
-  dileptonTree->SetIsData(isData);
-  dileptonTree->SetProcessID(0);
-  dileptonTree->SetFillNtupleType(1);
+  skimOutput->SetMaxFileSize(10 * 1024); // 10 GB - should never exceed
+  skimOutput->SetFileName(outputName);
+  skimOutput->SetPathName(".");
 
-  MonoJetTreeWriter *wlnuTree = new MonoJetTreeWriter("MonoJetTreeWriter_wlnu");
-  wlnuTree->SetTriggerObjectsName(hltModP->GetOutputName());
-  wlnuTree->SetMetName(metCorrT0T1Shift->GetOutputName());
-  wlnuTree->SetMetFromBranch(kFALSE);
-  wlnuTree->SetPhotonsFromBranch(kFALSE);
-  wlnuTree->SetPhotonsName(photonCleaningMod->GetOutputName());
-  wlnuTree->SetElectronsFromBranch(kFALSE);
-  wlnuTree->SetElectronsName(electronCleaning->GetOutputName());
-  wlnuTree->SetMuonsFromBranch(kFALSE);
-  wlnuTree->SetMuonsName(muonId->GetOutputName());
-  wlnuTree->SetTausFromBranch(kFALSE);
-  wlnuTree->SetTausName(pfTauCleaningMod->GetOutputName());
-  wlnuTree->SetJetsFromBranch(kFALSE);
-  wlnuTree->SetJetsName(jetCleaning->GetOutputName());
-  wlnuTree->SetPVFromBranch(kFALSE);
-  wlnuTree->SetPVName(goodPvMod->GetOutputName());
-  wlnuTree->SetLeptonsName(merger->GetOutputName());
-  wlnuTree->SetIsData(isData);
-  wlnuTree->SetProcessID(0);
-  wlnuTree->SetFillNtupleType(2);
+  modules.push_back(skimOutput);
 
   //------------------------------------------------------------------------------------------------
   // making the analysis chain
   //------------------------------------------------------------------------------------------------
-  // this is how it always starts
-  runLumiSel       ->Add(generatorMod);
-  generatorMod     ->Add(goodPvMod);
-  goodPvMod        ->Add(hltModP);
-  // photon regression
-  hltModP          ->Add(photonReg);
-  // simple object id modules
-  photonReg        ->Add(SepPUMod); 
-  SepPUMod         ->Add(muonId);
-  muonId           ->Add(eleIdMod);
-  eleIdMod	   ->Add(electronCleaning);
-  electronCleaning ->Add(merger);
-  merger           ->Add(photonIDMod);
-  photonIDMod	   ->Add(photonCleaningMod);
-  photonCleaningMod->Add(pfTauIDMod);
-  pfTauIDMod       ->Add(pfTauCleaningMod);
-  pfTauCleaningMod ->Add(pubJet);
-  pubJet           ->Add(jetCorr);
-  jetCorr          ->Add(metCorrT0T1Shift);
-  metCorrT0T1Shift ->Add(jetID);
-  jetID            ->Add(jetCleaning);
-   
-  // Jet+met selection
-  jetCleaning      ->Add(jetPlusMet);
-  jetPlusMet       ->Add(jetPlusMetTree);
-
-  // Dilepton selection
-  jetCleaning      ->Add(dilepton);
-  dilepton         ->Add(dileptonTree);
-
-  // Wlnu selection
-  jetCleaning      ->Add(wlnu);
-  wlnu	           ->Add(wlnuTree);
+  auto mItr(modules.begin());
+  while (true) {
+    auto* mod = *(mItr++);
+    if (mItr == modules.end())
+      break;
+    mod->Add(*mItr);
+  }
 
   //------------------------------------------------------------------------------------------------
   // setup analysis
   //------------------------------------------------------------------------------------------------
   Analysis *ana = new Analysis;
+  ana->SetUseCacher(1);
   ana->SetUseHLT(kTRUE);
-  ana->SetKeepHierarchy(kTRUE);
-  ana->SetSuperModule(runLumiSel);
+  ana->SetKeepHierarchy(kFALSE);
   ana->SetPrintScale(100);
+  ana->SetOutputName(outputName + "_hist.root");
   if (nEvents >= 0)
     ana->SetProcessNEvents(nEvents);
+
+  ana->AddSuperModule(modules.front());
 
   //------------------------------------------------------------------------------------------------
   // organize input
@@ -542,83 +399,37 @@ void runMonoJetSkim(const char *fileset    = "0000",
   TString skimDataset = TString(dataset)+TString("/") +TString(skim);
   Dataset *d = NULL;
   if (TString(skim).CompareTo("noskim") == 0)
-    d = c->FindDataset(book,dataset,fileset);
+    d = c->FindDataset(book,dataset,fileset, 1); // 1 to use smartcache
   else
-    d = c->FindDataset(book,skimDataset.Data(),fileset);
+    d = c->FindDataset(book,skimDataset.Data(),fileset, 1);
   ana->AddDataset(d);
-
-  //------------------------------------------------------------------------------------------------
-  // organize hist/ntuple output
-  //------------------------------------------------------------------------------------------------
-  ana->SetOutputName("test.root");
   ana->SetCacheSize(0);
-
-  //------------------------------------------------------------------------------------------------
-  // organize root output
-  //------------------------------------------------------------------------------------------------
-  OutputMod *outMod = new OutputMod;
-  outMod->Drop("*");
-  outMod->Keep("EventHeader");
-  if (! isData) {
-    outMod->Keep("MCEventInfo");
-    outMod->Keep("MCParticles");
-  }
-
-  TString rootFile = TString(outputName);
-  rootFile += TString("_") + TString(dataset) + TString("_") + TString(skim);
-  if (TString(fileset) != TString(""))
-    rootFile += TString("_") + TString(fileset);
-  outMod->SetFileName(rootFile);
-  outMod->SetPathName(".");
-
-  // Last step is the output module
-  jetPlusMetTree->Add(outMod);
-  dileptonTree->Add(outMod);
-  wlnuTree->Add(outMod);
 
   //------------------------------------------------------------------------------------------------
   // Say what we are doing
   //------------------------------------------------------------------------------------------------
   printf("\n==== PARAMETER SUMMARY FOR THIS JOB ====\n");
-  printf("\n JSON file: %s\n  and overlap cut: %f (%s)\n",jsonFile.Data(),overlapCut,overlap);
+  printf("\n JSON file: %s\n",jsonFile.Data());
   printf("\n Rely on Catalog: %s\n",catalogDir);
   printf("  -> Book: %s  Dataset: %s  Skim: %s  Fileset: %s <-\n",book,dataset,skim,fileset);
-  printf("\n Root output: %s\n\n",rootFile.Data());
   printf("\n========================================\n");
+
+  std::cout << std::endl;
+  std::cout << "+++++ ANALYSIS FLOW +++++" << std::endl;
+  ana->PrintModuleTree();
+  std::cout << std::endl;
+  std::cout << "+++++++++++++++++++++++++" << std::endl;
 
   //------------------------------------------------------------------------------------------------
   // run the analysis after successful initialisation
   //------------------------------------------------------------------------------------------------
   ana->Run(false);
 
+  delete ana; // all modules deleted recursively
+
+  // rename the output file so that condor can see it
+  gSystem->Rename("./" + outputName + "_000.root", "./" + outputName + ".root");
+
   return;
 }
 
-int decodeEnv(char* json, char* overlap, float overlapCut, char* path)
-{
-  if (gSystem->Getenv("MIT_PROD_JSON"))
-    sprintf(json,   "%s",gSystem->Getenv("MIT_PROD_JSON"));
-  else {
-    printf(" JSON file was not properly defined. EXIT!\n");
-    return -1;
-  }
-  if (gSystem->Getenv("MIT_PROD_OVERLAP")) {
-    sprintf(overlap,"%s",gSystem->Getenv("MIT_PROD_OVERLAP"));
-    if (EOF == sscanf(overlap,"%f",&overlapCut)) {
-      printf(" Overlap was not properly defined. EXIT!\n");
-      return -1;
-    }
-  }
-  else {
-    printf(" OVERLAP file was not properly defined. EXIT!\n");
-    return -1;
-  }
-  if (gSystem->Getenv("CMSSW_BASE"))
-    sprintf(path,   "%s/src/MitPhysics/data/",gSystem->Getenv("CMSSW_BASE"));
-  else {
-    printf(" PATH was not properly defined. EXIT!\n");
-    return -1;
-  }
-
-  return 0;
-}

--- a/Skim/src/MonoJetAnalysisMod.cc
+++ b/Skim/src/MonoJetAnalysisMod.cc
@@ -1,0 +1,325 @@
+#include "MitPhysics/Skim/interface/MonoJetAnalysisMod.h"
+
+#include "MitAna/DataTree/interface/MetCol.h"
+#include "MitAna/DataTree/interface/ElectronCol.h"
+#include "MitAna/DataTree/interface/MuonCol.h"
+#include "MitAna/DataTree/interface/PFTauCol.h"
+#include "MitAna/DataTree/interface/PhotonCol.h"
+#include "MitAna/DataTree/interface/JetCol.h"
+#include "MitAna/DataTree/interface/PFJet.h"
+#include "MitCommon/MathTools/interface/MathUtils.h"
+
+#include <limits>
+
+using namespace mithep;
+ClassImp(mithep::MonoJetAnalysisMod)
+
+TString MonoJetAnalysisMod::fgMonoJetCategories[nMonoJetCategories] = {
+  "Signal",
+  "Dielectron",
+  "Dimuon",
+  "SingleElectron",
+  "SingleMuon",
+  "Photon"
+};
+
+//--------------------------------------------------------------------------------------------------
+MonoJetAnalysisMod::MonoJetAnalysisMod(const char *name, const char *title) :
+  BaseMod(name, title)
+{
+  // cuts
+  Double_t dbig = std::numeric_limits<double>::max();
+  std::fill_n(fCategoryActive, nMonoJetCategories, false);
+  std::fill_n(fMaxNumJets, nMonoJetCategories, 0);
+  std::fill_n(fMinLeadJetPt, nMonoJetCategories, dbig);
+  std::fill_n(fMaxJetEta, nMonoJetCategories, 0.);
+  std::fill_n(fMinMetPt, nMonoJetCategories, dbig);
+  std::fill_n(fMinChargedHadronFrac, nMonoJetCategories, dbig);
+  std::fill_n(fMaxNeutralHadronFrac, nMonoJetCategories, 0.);
+  std::fill_n(fMaxNeutralEmFrac, nMonoJetCategories, 0.);
+
+  fCategoryFlags.Resize(nMonoJetCategories);
+}
+
+//--------------------------------------------------------------------------------------------------
+void
+MonoJetAnalysisMod::SlaveBegin()
+{
+  // Selection Histograms
+  for(unsigned iCat = 0; iCat != nMonoJetCategories; ++iCat){
+    if (!fCategoryActive[iCat])
+      continue;
+
+    // Histograms after preselection
+    AddTH1(fCutflow[iCat], "hCutflow" + fgMonoJetCategories[iCat], ";;Events", nCuts, 0., nCuts);
+    auto* xaxis = fCutflow[iCat]->GetXaxis();
+    xaxis->SetBinLabel(cAll + 1, "All");
+    xaxis->SetBinLabel(cNElectrons + 1, "NElectrons");
+    xaxis->SetBinLabel(cNMuons + 1, "NMuons");
+    xaxis->SetBinLabel(cNPhotons + 1, "NPhotons");
+    xaxis->SetBinLabel(cNTaus + 1, "NTaus");
+    xaxis->SetBinLabel(cLeadJet + 1, "LeadJet");
+    xaxis->SetBinLabel(cNJets + 1, "NJets");
+    xaxis->SetBinLabel(cMet + 1, "Met");
+
+    AddTH1(fRealMetPt[iCat],  "hRealMetPt" + fgMonoJetCategories[iCat], ";Real E_{T}^{miss} (GeV);Events / 4 GeV", 100, 0., 400.);
+    AddTH1(fMetPt[iCat],  "hMetPt" + fgMonoJetCategories[iCat], ";Emul. E_{T}^{miss} (GeV);Events / 4 GeV", 100, 0., 400.);
+    AddTH1(fJetPt[iCat],  "hJetPt" + fgMonoJetCategories[iCat], ";Jet p_{T} (GeV);Events / 4 GeV", 100, 0., 400.);
+    AddTH1(fJetEta[iCat], "hJetEta" + fgMonoJetCategories[iCat],";Jet #eta;Events / 0.2", 50, -5., 5.);
+  }
+
+  PublishObj(&fCategoryFlags);
+
+  fNEventsSelected = 0;
+}
+
+//--------------------------------------------------------------------------------------------------
+void
+MonoJetAnalysisMod::Process()
+{
+  auto* mets = GetObject<MetCol>(fMetName);
+  if (!mets)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fMetName);
+  auto* met = mets->At(0);
+
+  auto* jets = GetObject<JetCol>(fJetsName);
+  if (!jets)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fJetsName);
+
+  auto* electrons = GetObject<ElectronCol>(fVetoElectronsName);
+  if (!electrons)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fVetoElectronsName);
+  auto* electronMask = GetObject<NFArrBool>(fElectronMaskName);
+  if (!electronMask)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fElectronMaskName);
+
+  auto* muons = GetObject<MuonCol>(fVetoMuonsName);
+  if (!muons)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fVetoMuonsName);
+  auto* muonMask = GetObject<NFArrBool>(fMuonMaskName);
+  if (!muonMask)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fMuonMaskName);
+
+  auto* taus = GetObject<PFTauCol>(fVetoTausName);
+  if (!taus)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fVetoTausName);
+
+  auto* photons = GetObject<PhotonCol>(fVetoPhotonsName);
+  if (!photons)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fVetoPhotonsName);
+  auto* photonMask = GetObject<NFArrBool>(fPhotonMaskName);
+  if (!photonMask)
+    SendError(kAbortAnalysis, "Process", "Could not find " + fPhotonMaskName);
+
+  bool skipEvent = true;
+
+  for (unsigned iCat = 0; iCat != nMonoJetCategories; ++iCat) {
+    fCategoryFlags.At(iCat) = false;
+    
+    if (!fCategoryActive[iCat])
+      continue;
+
+    fCutflow[iCat]->Fill(cAll);
+
+    // Cuts based on object multiplicities
+
+    switch (iCat) {
+    case kDielectron:
+      // Mask applied on top of veto electrons
+      // -> there should be only two entries and both must be true
+      if (electronMask->GetEntries() != 2 || !(electronMask->At(0) && electronMask->At(1)))
+        continue;
+      break;
+    case kSingleElectron:
+      if (electronMask->GetEntries() != 1 || !electronMask->At(0))
+        continue;
+      break;
+    default:
+      if (electrons->GetEntries() != 0)
+        continue;
+      break;
+    }
+
+    fCutflow[iCat]->Fill(cNElectrons);
+
+    switch (iCat) {
+    case kDimuon:
+      if (muonMask->GetEntries() != 2 || !(muonMask->At(0) && muonMask->At(1)))
+        continue;
+      break;
+    case kSingleMuon:
+      if (muonMask->GetEntries() != 1 || !muonMask->At(0))
+        continue;
+      break;
+    default:
+      if (muons->GetEntries() != 0)
+        continue;
+      break;
+    }
+
+    fCutflow[iCat]->Fill(cNMuons);
+
+    if (taus->GetEntries() != 0)
+      continue;
+
+    fCutflow[iCat]->Fill(cNTaus);
+
+    switch (iCat) {
+    case kPhoton:
+      if (photonMask->GetEntries() != 1 || !photonMask->At(0))
+        continue;
+      break;
+    default:
+      if (photons->GetEntries() != 0)
+        continue;
+      break;
+    };
+
+    fCutflow[iCat]->Fill(cNPhotons);
+    
+    // Cuts on the jets
+    std::vector<Jet*> goodJets;
+
+    for (unsigned iJ = 0; iJ < jets->GetEntries(); ++iJ) {
+      auto& jet(*jets->At(iJ));
+      if (jet.AbsEta() >= fMaxJetEta[iCat])
+        continue;
+
+      double rawE = jet.RawMom().E();
+      auto& pfJet(static_cast<PFJet&>(jet));
+
+      if (pfJet.ChargedHadronEnergy() / rawE < fMinChargedHadronFrac[iCat])
+        continue;
+
+      if (pfJet.NeutralHadronEnergy() / rawE > fMaxNeutralHadronFrac[iCat])
+        continue;
+
+      if (pfJet.NeutralEmEnergy() / rawE > fMaxNeutralEmFrac[iCat])
+        continue;
+
+      switch (iCat) {
+      case kDielectron:
+        if (MathUtils::DeltaR(jet, *electrons->At(1)) < 0.4)
+          continue;
+        //fallthrough
+      case kSingleElectron:
+        if (MathUtils::DeltaR(jet, *electrons->At(0)) < 0.4)
+          continue;
+        break;
+      case kDimuon:
+        if (MathUtils::DeltaR(jet, *muons->At(1)) < 0.4)
+          continue;
+        //fallthrough
+      case kSingleMuon:
+        if (MathUtils::DeltaR(jet, *muons->At(0)) < 0.4)
+          continue;
+        break;
+      case kPhoton:
+        if (MathUtils::DeltaR(jet, *photons->At(0)) < 0.4)
+          continue;
+        break;
+      default:
+        break;
+      }
+
+      goodJets.push_back(&jet);
+    }
+
+    if (goodJets.size() == 0 || goodJets[0]->Pt() < fMinLeadJetPt[iCat])
+      continue;
+
+    fCutflow[iCat]->Fill(cLeadJet);
+
+    if (goodJets.size() > fMaxNumJets[iCat])
+      continue;
+
+    fCutflow[iCat]->Fill(cNJets);
+
+    // Cut on met
+    double metPt = 0.;
+    switch (iCat) {
+    case kSignal:
+      metPt = met->Pt();
+      break;
+
+    case kDielectron:
+      {
+        auto emulMet(met->Mom());
+        emulMet += electrons->At(0)->Mom();
+        emulMet += electrons->At(1)->Mom();
+        metPt = emulMet.Pt();
+      }
+      break;
+
+    case kDimuon:
+      {
+        auto emulMet(met->Mom());
+        emulMet += muons->At(0)->Mom();
+        emulMet += muons->At(1)->Mom();
+        metPt = emulMet.Pt();
+      }
+      break;
+
+    case kSingleElectron:
+      {
+        auto emulMet(met->Mom());
+        emulMet += electrons->At(0)->Mom();
+        metPt = emulMet.Pt();
+      }
+      break;
+
+    case kSingleMuon:
+      {
+        auto emulMet(met->Mom());
+        emulMet += muons->At(0)->Mom();
+        metPt = emulMet.Pt();
+      }
+      break;
+
+    case kPhoton:
+      {
+        auto& photon(*photons->At(0));
+        auto emulMet(met->Mom());
+        emulMet += photon.Mom();
+        for (unsigned iF = 0; iF != photon.NFootprintCandidates(); ++iF)
+          emulMet += photon.FootprintCandidate(iF)->Mom();
+        metPt = emulMet.Pt();
+      }
+      break;
+
+    default:
+      break;
+    }
+
+    if (metPt < fMinMetPt[iCat])
+      continue;
+
+    fCutflow[iCat]->Fill(cMet);
+
+    // Passed category cuts
+    fCategoryFlags.At(iCat) = true;
+    skipEvent = false;
+
+    // Fill Preselection Histograms
+    fRealMetPt[iCat]->Fill(met->Pt());
+    fMetPt[iCat]->Fill(metPt);
+    for (auto* jet : goodJets) {
+      fJetPt[iCat]->Fill(jet->Pt());
+      fJetEta[iCat]->Fill(jet->Eta());
+    }
+  }
+
+  // Skip the event if does not passes the cuts
+  if (skipEvent)
+    SkipEvent();
+  else
+    ++fNEventsSelected;
+}
+
+//--------------------------------------------------------------------------------------------------
+void MonoJetAnalysisMod::SlaveTerminate()
+{
+  Info("SlaveTerminate", "Selected events on MonoJetAnalysisMod: %d", fNEventsSelected);
+
+  RetractObj(fCategoryFlags.GetName());
+}


### PR DESCRIPTION
Added MonoJetAnalysisMod to Skim. The driver macro is Skim/macros/runMonoJetSkim.C.
The module takes jets, met, and veto objects as input and outputs an array of boolean corresponding to pass/fail of each event category.
Lepton selection efficiency in single lepton calibration regions seem somewhat low. This needs to be studied.
