### PR TITLE
Goodpv metcorr skim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ data
 *~
 *.root
 *.pcm
+*.so
+*.d

--- a/Mods/interface/GoodPVFilterMod.h
+++ b/Mods/interface/GoodPVFilterMod.h
@@ -10,75 +10,66 @@
 #ifndef MITMODS_MODS_GOODPVFILTERMOD_H
 #define MITMODS_MODS_GOODPVFILTERMOD_H
 
-#include <string>
-#include <TString.h>
-#include <TH1F.h>
-#include "MitAna/DataTree/interface/VertexFwd.h" 
-#include "MitAna/DataTree/interface/PileupInfoFwd.h"
-#include "MitAna/TreeMod/interface/BaseMod.h" 
+#include "MitAna/TreeMod/interface/BaseMod.h"
+#include "MitAna/DataTree/interface/Names.h"
+#include "MitPhysics/Init/interface/ModNames.h"
 
-namespace mithep 
-{
+#include "TString.h"
+#include "TH1F.h"
+
+namespace mithep {
+
   class GoodPVFilterMod : public BaseMod {
-    public:
-      
-      enum ECuts {
-        eNTracks,
-        eNDof,
-        eZ,
-        eRho
-      };
-      
-      GoodPVFilterMod(const char *name="GoodPVFilterMod", const char *title="Good PV Filter Module");
-      ~GoodPVFilterMod();
+  public:
+    enum ECuts {
+      eNTracks,
+      eNDof,
+      eZ,
+      eRho,
+      nCuts
+    };
 
-      Int_t                       GetNEvents()      const { return fNEvents;       }
-      Int_t                       GetNAccepted()    const { return fNAcceped;      }
-      Int_t                       GetNFailed()      const { return fNFailed;       }
-      const char                 *GetOutputName()   const { return fGoodVertexesName; }
-      const char                 *GetGoodVertexesName() const { return GetOutputName(); }
-      void                        SetAbortIfNotAccepted(Bool_t b)   { fAbort = b;           }
-      void                        SetIsMC(Bool_t b)                 { fIsMC = b;            }
-      void                        SetMinVertexNTracks(UInt_t n)     { fMinVertexNTracks = n;}
-      void                        SetMinNDof(UInt_t n)              { fMinNDof = n; 	    }
-      void                        SetMaxAbsZ(Double_t x)  	    { fMaxAbsZ = x; 	    }
-      void                        SetMaxRho(Double_t x)   	    { fMaxRho = x;          }
-      void                        SetVertexesName(TString s)        { fVertexesName = s;    }
-      void                        SetGoodVertexesName(TString s)    { SetOutputName(s);     }
-      void                        SetOutputName(TString s)          { fGoodVertexesName = s; }
-      
+    GoodPVFilterMod(const char* name = "GoodPVFilterMod", const char* title = "Good PV Filter Module") : BaseMod(name, title) {}
+    ~GoodPVFilterMod() {}
 
-    protected:
-      void                        BeginRun();
-      const BitMask8              FailedCuts(const mithep::Vertex *v) const;
-      virtual void                OnAccepted()  {/*could be implemented in derived classes*/}
-      virtual void                OnFailed()    {/*could be implemented in derived classes*/}
-      void                        Process();
-      void                        SlaveBegin();
-      void                        SlaveTerminate();
+    char const* GetOutputName() const { return fGoodVertexesName; }
+    char const* GetGoodVertexesName() const { return GetOutputName(); }
 
-      Bool_t                      fAbort;         //=true then abort (sub-)modules if not accepted
-      Bool_t                      fIsMC;
-      UInt_t                      fMinVertexNTracks; //minimum number of tracks for the vertex
-      UInt_t                      fMinNDof;       //minimum number of degrees of freedom
-      Double_t                    fMaxAbsZ;       //maximum abs(z) of the vertex
-      Double_t                    fMaxRho;        //maximum rho of the vertex
-      TString                     fVertexesName;  //Name of PV collection
-      TString                     fGoodVertexesName; //Name of newPV collection
-      TString                     fPileupInfoName;
-      Int_t                       fNEvents;       //!number of processed events
-      Int_t                       fNAcceped;      //!number of accepted events
-      Int_t                       fNFailed;       //!number of failed events
-      TH1F                       *hVertexNTracks;
-      TH1F                       *hVertexNDof;
-      TH1F                       *hVertexRho;
-      TH1F                       *hVertexZ;
-      TH1F                       *hNVtx;
-      TH1F                       *hNGoodVtx;
-      TH1D                       *hNGenVtx;
-      TH1D                       *hNPU;
+    void SetAbortIfNotAccepted(Bool_t b)    { fAbort = b; }
+    void SetMinVertexNTracks(UInt_t n)      { fMinVertexNTracks = n; }
+    void SetMinNDof(UInt_t n)               { fMinNDof = n; }
+    void SetMaxAbsZ(Double_t x)  	    { fMaxAbsZ = x; }
+    void SetMaxRho(Double_t x)   	    { fMaxRho = x; }
+    void SetInputName(char const* s)        { fVertexesName = s; }
+    void SetVertexesName(char const* s)     { SetInputName(s); }
+    void SetOutputName(char const* s)       { fGoodVertexesName = s; }
+    void SetGoodVertexesName(char const* s) { SetOutputName(s); }
 
-    ClassDef(GoodPVFilterMod, 1) // L1 TAM module
+  protected:
+    void Process() override;
+    void SlaveBegin() override;
+    void SlaveTerminate() override;
+
+    virtual void OnAccepted()  {/*could be implemented in derived classes*/}
+    virtual void OnFailed()    {/*could be implemented in derived classes*/}
+
+    Bool_t   fAbort{kTRUE};         //=true then abort (sub-)modules if not accepted
+    UInt_t   fMinVertexNTracks{0}; //minimum number of tracks for the vertex
+    UInt_t   fMinNDof{5};       //minimum number of degrees of freedom
+    Double_t fMaxAbsZ{15.};       //maximum abs(z) of the vertex
+    Double_t fMaxRho{2.};        //maximum rho of the vertex
+    TString  fVertexesName{Names::gkPVBrn};  //Name of PV collection
+    TString  fGoodVertexesName{ModNames::gkGoodVertexesName}; //Name of newPV collection
+
+    TH1F* hVertexNTracks = 0;
+    TH1F* hVertexNDof = 0;
+    TH1F* hVertexRho = 0;
+    TH1F* hVertexZ = 0;
+    TH1F* hNVtx = 0;
+    TH1F* hNGoodVtx = 0;
+
+    ClassDef(GoodPVFilterMod, 1)
   };
+
 }
 #endif

--- a/Mods/interface/IdMod.h
+++ b/Mods/interface/IdMod.h
@@ -57,6 +57,7 @@ namespace mithep {
     Double_t GetPtMin() const { return fPtMin; }
     Double_t GetEtaMax() const { return fEtaMax; }
     UInt_t GetMinOutput() const { return fMinOutput; }
+    UInt_t GetMaxOutput() const { return fMaxOutput; }
 
     void SetInputName(char const* n) { fInputName = n; }
     void SetOutputName(char const* n) { fOutputName = n; }
@@ -79,6 +80,7 @@ namespace mithep {
     void SetPtMin(Double_t m) { fPtMin = m; }
     void SetEtaMax(Double_t m) { fEtaMax = m; }
     void SetMinOutput(UInt_t m) { fMinOutput = m; }
+    void SetMaxOutput(UInt_t m) { fMaxOutput = m; }
 
   protected:
     void SlaveBegin() override;
@@ -142,6 +144,7 @@ namespace mithep {
 
     Bool_t   fIsFilterMode = kTRUE;
     UInt_t   fMinOutput = 0;
+    UInt_t   fMaxOutput = 0xffffffff;
     UInt_t   fIdType = 0xffffffff;
     UInt_t   fIsoType = 0xffffffff;
     Double_t fPtMin = 0.;
@@ -233,7 +236,7 @@ namespace mithep {
       }
     }
   
-    if (nGoodObjects < fMinOutput) {
+    if (nGoodObjects < fMinOutput || nGoodObjects > fMaxOutput) {
       SkipEvent();
       return;
     }

--- a/Mods/interface/MetCorrectionMod.h
+++ b/Mods/interface/MetCorrectionMod.h
@@ -5,7 +5,7 @@
 // The methods are synchronized with JetMET POG 2012 studies, documented in this twiki
 // https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMetAnalysis#7_7_6_MET_Corrections
 //
-// Authors: L.Di Matteo
+// Authors: L.Di Matteo, Y.Iiyama
 //--------------------------------------------------------------------------------------------------
 
 #ifndef MITPHYSICS_MODS_METCORRECTIONMOD_H
@@ -13,28 +13,31 @@
 
 #include "MitAna/TreeMod/interface/BaseMod.h"
 #include "MitPhysics/Utils/interface/JetCorrector.h"
-#include "MitAna/DataTree/interface/MetCol.h"
 #include "MitAna/DataTree/interface/PileupEnergyDensity.h"
 
 #include "MitAna/DataTree/interface/Names.h"
+#include "MitAna/DataTree/interface/ObjTypes.h"
 #include "MitPhysics/Init/interface/ModNames.h"
 
 #include "TFormula.h"
 
 namespace mithep {
 
+  class BaseCollection;
+
   // (Get|Set)ExprShift(Data|MC)P(x|y) is removed. Use IsData flag + (Get|Set)ExprShiftP(x|y) instead.
 
   class MetCorrectionMod : public BaseMod {
   public:
     MetCorrectionMod(const char* name="MetCorrectionMod",
-                     const char* title="Met correction module");
+                     const char* title="Met correction module") : BaseMod(name, title) {}
     ~MetCorrectionMod() {}
 
     const char*   GetInputName() const       { return fMetName; }
-    const char*   GetOutputName() const      { return fOutput.GetName(); }
+    const char*   GetOutputName() const      { return fOutputName; }
     const char*   GetCorrectedName() const   { return GetOutputName(); }
     const char*   GetJetsName() const        { return fJetsName; }
+    UInt_t        GetOutputType() const      { return fOutputType; }
     Double_t      GetMinDz() const           { return fMinDz; }
     const char*   GetExprType0();
     const char*   GetExprShiftPx();
@@ -45,9 +48,10 @@ namespace mithep {
     Bool_t        GetSkipMuons() const       { return fSkipMuons; }
 
     void SetInputName(const char *name)        { fMetName = name; }
-    void SetOutputName(const char *name)       { fOutput.SetName(name); }
+    void SetOutputName(const char *name)       { fOutputName = name; }
     void SetCorrectedName(const char *name)    { SetOutputName(name); }
     void SetJetsName(const char *name)         { fJetsName = name; }
+    void SetOutputType(UInt_t t)               { fOutputType = t; }
     void SetMinDz(Double_t d)                  { fMinDz = d; }
     void ApplyType0(bool b)                    { fApplyType0 = b; }
     void ApplyType1(bool b)                    { fApplyType1 = b; }
@@ -72,6 +76,7 @@ namespace mithep {
     void MakeJetCorrector();
     void MakeFormula(UInt_t idx, char const* expr = "");
 
+    TString       fOutputName{"PFMetT0T1Shift"};
     TString       fMetName{"PFMet"};                           //name of met collection (input)
     TString       fJetsName{Names::gkPFJetBrn};                //name of uncorrected jet collection (input)
     TString       fPFCandidatesName{Names::gkPFCandidatesBrn}; //name of PF candidates collection (input)
@@ -97,7 +102,8 @@ namespace mithep {
     Bool_t        fIsData = kTRUE; //flag for data/MC distinction
     Bool_t        fPrint = kFALSE; //flag for debug print out
 
-    MetOArr       fOutput{1, "PFMetT0T1Shift"}; //using ObjArray to accomodate different MET types
+    UInt_t          fOutputType = kPFMet;
+    BaseCollection* fOutput = 0;
 
     ClassDef(MetCorrectionMod, 1) // met correction module
   };

--- a/Mods/python/GoodPVFilterMod.py
+++ b/Mods/python/GoodPVFilterMod.py
@@ -5,6 +5,5 @@ goodPVFilterMod = mithep.GoodPVFilterMod(
     MinNDof = 4,
     MaxAbsZ = 24.,
     MaxRho = 2.,
-    IsMC = not analysis.isRealData,
     VertexesName = mithep.Names.gkPVBrn
 )

--- a/Mods/src/GoodPVFilterMod.cc
+++ b/Mods/src/GoodPVFilterMod.cc
@@ -1,188 +1,121 @@
 #include "MitPhysics/Mods/interface/GoodPVFilterMod.h"
-#include <TFile.h>
-#include <TTree.h>
-#include "MitAna/DataTree/interface/Names.h"
-#include "MitPhysics/Init/interface/ModNames.h"
-#include "MitAna/DataTree/interface/Vertex.h"
-#include "MitAna/DataTree/interface/PileupInfo.h"
-
+#include "MitAna/DataTree/interface/VertexCol.h"
 
 using namespace mithep;
 
 ClassImp(mithep::GoodPVFilterMod)
 
 //--------------------------------------------------------------------------------------------------
-GoodPVFilterMod::GoodPVFilterMod(const char *name, const char *title) : 
-  BaseMod(name,title),
-  fAbort(kTRUE),
-  fIsMC(kFALSE),
-  fMinVertexNTracks(0),
-  fMinNDof(5),
-  fMaxAbsZ(15.0),
-  fMaxRho(2.0),
-  fGoodVertexesName(ModNames::gkGoodVertexesName),
-  fPileupInfoName("PileupInfo"),
-  fNEvents(0),
-  fNAcceped(0),
-  fNFailed(0),
-  hVertexNTracks(0),
-  hVertexRho(0),
-  hVertexZ(0)
-{
-  // Constructor. 
-}
-
-//--------------------------------------------------------------------------------------------------
-GoodPVFilterMod::~GoodPVFilterMod() 
-{
-  // Destructor.
-}
-
-
-//--------------------------------------------------------------------------------------------------
-void GoodPVFilterMod::BeginRun()
-{
-  
-}
-
-//--------------------------------------------------------------------------------------------------
-const BitMask8 GoodPVFilterMod::FailedCuts(const Vertex *v) const
-{
-  BitMask8 failedCuts;
-  
-  if (v->NTracksFit() < fMinVertexNTracks)
-    failedCuts.SetBit(eNTracks);
-  
-  if (v->Ndof() < fMinNDof)
-    failedCuts.SetBit(eNDof);
-  
-  if (TMath::Abs(v->Position().Z()) > fMaxAbsZ)
-    failedCuts.SetBit(eZ);
-  
-  if (v->Position().Rho() > fMaxRho)
-    failedCuts.SetBit(eRho);
-  
-  return failedCuts;
-  
-}
-
-//--------------------------------------------------------------------------------------------------
-void GoodPVFilterMod::Process()
+void
+GoodPVFilterMod::Process()
 {
   auto* vertices = GetObject<VertexCol>(fVertexesName);
-  PileupInfoCol const* pileupInfo = 0;
-  if (fIsMC)
-    pileupInfo = GetObject<PileupInfoCol>(fPileupInfoName);
-  
+
   VertexOArr *GoodVertexes = new VertexOArr;
   GoodVertexes->SetName(fGoodVertexesName);
-  
+
   // Increment counters and stop further processing of an event if current run is excluded
 
-  ++fNEvents; 
-  Bool_t goodVertex = kFALSE;
-  
-  for (UInt_t i=0; i<vertices->GetEntries(); ++i) {
-    const Vertex *v = vertices->At(i);
-    BitMask8 failed = FailedCuts(v);
-    
+  for (unsigned iV = 0; iV != vertices->GetEntries(); ++iV) {
+    auto& vertex(*vertices->At(iV));
+
+    unsigned nTracks = vertex.NTracksFit();
+    unsigned nDof = vertex.Ndof();
+    double z = vertex.Position().Z();
+    double rho = vertex.Position().Rho();
+
+    BitMask8 failed;
+
+    if (nTracks < fMinVertexNTracks)
+      failed.SetBit(eNTracks);
+
+    if (nDof < fMinNDof)
+      failed.SetBit(eNDof);
+
+    if (std::abs(z) > fMaxAbsZ)
+      failed.SetBit(eZ);
+
+    if (rho > fMaxRho)
+      failed.SetBit(eRho);
+
     if (failed.NBitsSet() > 1)
       continue;
-       
-    BitMask8 failedNTracks = failed;
+
+    BitMask8 failedNTracks(failed);
     failedNTracks.ClearBit(eNTracks);
-    if (!failedNTracks.NBitsSet())
-      hVertexNTracks->Fill(v->NTracksFit());
-    
-    BitMask8 failedNDof = failed;
-    failedNTracks.ClearBit(eNDof);
-    if (!failedNDof.NBitsSet())
-      hVertexNDof->Fill(v->Ndof());
-    
-    BitMask8 failedZ = failed;
+    if (failedNTracks.NBitsSet() == 0)
+      hVertexNTracks->Fill(nTracks);
+
+    BitMask8 failedNDof(failed);
+    failedNDof.ClearBit(eNDof);
+    if (failedNDof.NBitsSet() == 0)
+      hVertexNDof->Fill(nDof);
+
+    BitMask8 failedZ(failed);
     failedZ.ClearBit(eZ);
-    if (!failedZ.NBitsSet())
-      hVertexZ->Fill(v->Position().Z());
-    
-    BitMask8 failedRho = failed;
+    if (failedZ.NBitsSet() == 0)
+      hVertexZ->Fill(z);
+
+    BitMask8 failedRho(failed);
     failedRho.ClearBit(eRho);
-    if (!failedRho.NBitsSet())
-      hVertexRho->Fill(v->Position().Rho());
-    
-    if (!failed.NBitsSet()) {
-      goodVertex = kTRUE;
-      v->Mark();
-      GoodVertexes->Add(v);
+    if (failedRho.NBitsSet() == 0)
+      hVertexRho->Fill(rho);
+
+    if (failed.NBitsSet() == 0) {
+      vertex.Mark();
+      GoodVertexes->Add(&vertex);
     }
   }
-  
+
   //fill histograms
   hNVtx->Fill(vertices->GetEntries());
   hNGoodVtx->Fill(GoodVertexes->GetEntries());
-  if (fIsMC) {
-    Int_t npu = -99;
-    for (UInt_t i=0; i<pileupInfo->GetEntries(); ++i) {
-      const PileupInfo *puinfo = pileupInfo->At(i);
-      if (puinfo->GetBunchCrossing()==0) {
-        npu = puinfo->GetPU_NumInteractions();
-        break;
-      }
-    }
-    hNGenVtx->Fill(1 + npu);
-    hNPU->Fill(npu);
-  }
 
   // add objects for other modules to use
-  AddObjThisEvt(GoodVertexes);  
-  
+  AddObjThisEvt(GoodVertexes);
+
   // take action if failed
-  if (!goodVertex) {
-    ++fNFailed;
+  if (GoodVertexes->GetEntries() == 0) {
     OnFailed();
-    if (fAbort) {
+    if (fAbort)
       SkipEvent(); // abort processing of this event by sub-modules
-    }
+
     return;
-  } 
-  //printf("goodvertex check 0\n");
+  }
+
   // take action if accepted
-  ++fNAcceped;
-  IncNEventsProcessed();
   OnAccepted();
+
+  IncNEventsProcessed();
 }
 
 //--------------------------------------------------------------------------------------------------
-void GoodPVFilterMod::SlaveBegin()
+void
+GoodPVFilterMod::SlaveBegin()
 {
   hVertexNTracks = new TH1F("hVertexNTracks", "hVertexNTracks", 401, -0.5,400.5);
   AddOutput(hVertexNTracks);
-  
+
   hVertexNDof = new TH1F("hVertexNDof", "hVertexNDof", 401, -0.5,400.5);
   AddOutput(hVertexNDof);
-  
+
   hVertexZ = new TH1F("hVertexZ", "hVertexZ", 100, -100.0, 100.0);
   AddOutput(hVertexZ);
-  
+
   hVertexRho = new TH1F("hVertexRho", "hVertexRho", 100, 0.0, 20.0);
   AddOutput(hVertexRho);
-  
-  hNVtx = new TH1F("hNVtx", "hNVtx", 51, -0.5, 50.5);
-  AddOutput(hNVtx);  
-  
-  hNGoodVtx = new TH1F("hNGoodVtx", "hNGoodVtx", 51, -0.5, 50.5);
-  AddOutput(hNGoodVtx);   
-  
-  hNGenVtx = new TH1D("hNGenVtx", "hNGenVtx", 51, -0.5, 50.5);
-  AddOutput(hNGenVtx);      
 
-  hNPU = new TH1D("hNPU", "hNPU", 51, -0.5, 50.5);
-  AddOutput(hNPU);      
+  hNVtx = new TH1F("hNVtx", "hNVtx", 51, -0.5, 50.5);
+  AddOutput(hNVtx);
+
+  hNGoodVtx = new TH1F("hNGoodVtx", "hNGoodVtx", 51, -0.5, 50.5);
+  AddOutput(hNGoodVtx);
 }
 
 //--------------------------------------------------------------------------------------------------
-void GoodPVFilterMod::SlaveTerminate()
+void
+GoodPVFilterMod::SlaveTerminate()
 {
   // Save number of accepted events.
-
   SaveNEventsProcessed();
 }

--- a/Skim/interface/MonoJetAnalysisMod.h
+++ b/Skim/interface/MonoJetAnalysisMod.h
@@ -44,6 +44,7 @@ namespace mithep {
     // Setting cut values
     void SetCategoryActive(UInt_t c, Bool_t a = kTRUE) { fCategoryActive[c] = a; }
     void AddTriggerName(UInt_t c, const char* n)       { fTriggerNames[c].push_back(n); }
+    void SetMinNumJets(UInt_t c, Int_t n)              { fMinNumJets[c] = n; }
     void SetMaxNumJets(UInt_t c, Int_t n)              { fMaxNumJets[c] = n; }
     void SetMinLeadJetPt(UInt_t c, Double_t x)         { fMinLeadJetPt[c] = x; }
     void SetMaxJetEta(UInt_t c, Double_t x)            { fMaxJetEta[c] = x; }
@@ -89,6 +90,7 @@ namespace mithep {
     std::vector<UInt_t> fTriggerIds[nMonoJetCategories]{};
 
     Bool_t   fCategoryActive[nMonoJetCategories] = {};
+    UInt_t   fMinNumJets[nMonoJetCategories] = {};
     UInt_t   fMaxNumJets[nMonoJetCategories] = {};
     Double_t fMinLeadJetPt[nMonoJetCategories] = {};
     Double_t fMaxJetEta[nMonoJetCategories] = {};

--- a/Skim/interface/MonoJetAnalysisMod.h
+++ b/Skim/interface/MonoJetAnalysisMod.h
@@ -52,6 +52,10 @@ namespace mithep {
     void SetMinChargedHadronFrac(UInt_t c, Double_t x) { fMinChargedHadronFrac[c] = x; }
     void SetMaxNeutralHadronFrac(UInt_t c, Double_t x) { fMaxNeutralHadronFrac[c] = x; }
     void SetMaxNeutralEmFrac(UInt_t c, Double_t x)     { fMaxNeutralEmFrac[c] = x; }
+    void SetVetoElectrons(UInt_t c, Bool_t v)          { fVetoElectrons[c] = v; }
+    void SetVetoMuons(UInt_t c, Bool_t v)              { fVetoMuons[c] = v; }
+    void SetVetoTaus(UInt_t c, Bool_t v)               { fVetoTaus[c] = v; }
+    void SetVetoPhotons(UInt_t c, Bool_t v)            { fVetoPhotons[c] = v; }
 
     void SetIgnoreTrigger(Bool_t i)                    { fIgnoreTrigger = i; }
 
@@ -98,6 +102,10 @@ namespace mithep {
     Double_t fMinChargedHadronFrac[nMonoJetCategories] = {};
     Double_t fMaxNeutralHadronFrac[nMonoJetCategories] = {};
     Double_t fMaxNeutralEmFrac[nMonoJetCategories] = {};
+    Bool_t   fVetoElectrons[nMonoJetCategories] = {};
+    Bool_t   fVetoMuons[nMonoJetCategories] = {};
+    Bool_t   fVetoTaus[nMonoJetCategories] = {};
+    Bool_t   fVetoPhotons[nMonoJetCategories] = {};
 
     Bool_t fIgnoreTrigger{kFALSE};
 

--- a/Skim/macros/rootlogon.C
+++ b/Skim/macros/rootlogon.C
@@ -26,7 +26,7 @@
   str = str + TString(" -lMitAnaCatalog -lMitAnaDataCont -lMitAnaDataTree -lMitAnaDataUtil");
   str = str + TString(" -lMitAnaPhysicsMod -lMitAnaTAM -lMitAnaTreeMod -lMitAnaUtils");
   str = str + TString(" -lMitAnaValidation");
-  str = str + TString(" -lMitPhysicsMods -lMitPhysicsSelMods -lMitPhysicsSkim");
+  str = str + TString(" -lMitPhysicsMods -lMitPhysicsSelMods -lMitPhysicsSkim -lMitPhysicsInit");
   gSystem->SetMakeSharedLib(str);
 
   // Make sure we have all include files

--- a/Skim/macros/runMonoJetSkim.C
+++ b/Skim/macros/runMonoJetSkim.C
@@ -37,10 +37,8 @@ void runMonoJetSkim(const char *fileset    = "0000",
                     int         nEvents    = 1000)
 {
   float maxJetEta       = 2.5;
-  float minMet          = 50.;
-  float minLeadJetPt    = 50.;
-  float zllMinMet       = 0.;
-  float zllMinLeadJetPt = 30.;
+  float minMet          = 100.;
+  float minLeadJetPt    = 100.;
 
   //------------------------------------------------------------------------------------------------
   // json parameters get passed through the environment
@@ -340,7 +338,6 @@ void runMonoJetSkim(const char *fileset    = "0000",
     monojetSel->SetCategoryActive(iCat, kTRUE);
     for (auto& name : triggerNames[iCat])
       monojetSel->AddTriggerName(iCat, name);
-    monojetSel->SetMinNumJets(iCat, 1);
     monojetSel->SetMaxNumJets(iCat, 0xffffffff);
     monojetSel->SetMaxJetEta(iCat, maxJetEta);
     monojetSel->SetMinChargedHadronFrac(iCat, 0.2); 
@@ -351,10 +348,12 @@ void runMonoJetSkim(const char *fileset    = "0000",
     switch (iCat) {
     case MonoJetAnalysisMod::kDielectron:
     case MonoJetAnalysisMod::kDimuon:
-      monojetSel->SetMinLeadJetPt(iCat, zllMinLeadJetPt);
-      monojetSel->SetMinMetPt(iCat, zllMinMet);
+      monojetSel->SetMinNumJets(iCat, 0);
+      monojetSel->SetMinMetPt(iCat, 0.);
+      monojetSel->SetVetoPhotons(iCat, false);
       break;
     default:
+      monojetSel->SetMinNumJets(iCat, 1);
       monojetSel->SetMinLeadJetPt(iCat, minLeadJetPt);
       monojetSel->SetMinMetPt(iCat, minMet);
       break;
@@ -372,25 +371,22 @@ void runMonoJetSkim(const char *fileset    = "0000",
     outputName += TString("_") + TString(fileset);
   
   OutputMod *skimOutput = new OutputMod;
-  skimOutput->Drop("*");
-  skimOutput->Keep("HLT*");
 
-  skimOutput->Keep("MC*");
-  skimOutput->Keep("PileupInfo");
-  skimOutput->Keep("Rho");
-  skimOutput->Keep("EvtSelData");
-  skimOutput->Keep("BeamSpot");
-  skimOutput->Keep("PrimaryVertexes");
-  skimOutput->Keep("PFMet");
-  skimOutput->Keep("AKt4PFJetsCHS");
-  skimOutput->Keep("AKt8PFJetsCHS");
-  skimOutput->Keep("Electrons");
-  skimOutput->Keep("Conversions");
-  skimOutput->Keep("*Stable*");
-  skimOutput->Keep("Muons");
-  skimOutput->Keep("HPSTaus");
-  skimOutput->Keep("Photons");
-  skimOutput->Keep("AKT4GenJets");
+  skimOutput->Keep("*");
+  skimOutput->Drop("L1TechBits*");
+  skimOutput->Drop("L1AlgoBits*");
+  skimOutput->Drop("MCVertexes");
+  skimOutput->Drop("PFEcal*SuperClusters");
+  skimOutput->Drop("*Tracks");
+  skimOutput->Drop("StandaloneMuonTracksWVtxConstraint");
+  skimOutput->Drop("PrimaryVertexesBeamSpot");
+  skimOutput->Drop("InclusiveSecondaryVertexes");
+  skimOutput->Drop("CosmicMuons");
+  skimOutput->Drop("MergedElectronsStable");
+  skimOutput->Drop("MergedConversions*");
+  skimOutput->Drop("AKT8GenJets");
+  skimOutput->Drop("AKt4PFJets");
+  skimOutput->Drop("DCASig");
   skimOutput->AddNewBranch(type1MetCorr->GetOutputName());
   skimOutput->AddNewBranch(monojetSel->GetCategoryFlagsName());
 
@@ -399,6 +395,8 @@ void runMonoJetSkim(const char *fileset    = "0000",
   skimOutput->SetPathName(".");
   skimOutput->SetCheckTamBr(false);
   skimOutput->SetKeepTamBr(false);
+  skimOutput->SetCheckBrDep(true);
+  skimOutput->SetUseBrDep(true);
 
   skimOutput->AddCondition(monojetSel);
 

--- a/Skim/macros/runMonoJetSkim.C
+++ b/Skim/macros/runMonoJetSkim.C
@@ -137,7 +137,6 @@ void runMonoJetSkim(const char *fileset    = "0000",
   goodPvMod->SetMinNDof(4.0);
   goodPvMod->SetMaxAbsZ(24.0);
   goodPvMod->SetMaxRho(2.0);
-  goodPvMod->SetIsMC(!isData);
   goodPvMod->SetVertexesName("PrimaryVertexes");
 
   modules.push_back(goodPvMod);
@@ -391,11 +390,14 @@ void runMonoJetSkim(const char *fileset    = "0000",
   skimOutput->Keep("HPSTaus");
   skimOutput->Keep("Photons");
   skimOutput->Keep("AKT4GenJets");
+  skimOutput->AddNewBranch(type1MetCorr->GetOutputName());
   skimOutput->AddNewBranch(monojetSel->GetCategoryFlagsName());
 
   skimOutput->SetMaxFileSize(10 * 1024); // 10 GB - should never exceed
   skimOutput->SetFileName(outputName);
   skimOutput->SetPathName(".");
+  skimOutput->SetCheckTamBr(false);
+  skimOutput->SetKeepTamBr(false);
 
   skimOutput->AddCondition(monojetSel);
 

--- a/Skim/macros/runMonoJetSkim.C
+++ b/Skim/macros/runMonoJetSkim.C
@@ -340,6 +340,7 @@ void runMonoJetSkim(const char *fileset    = "0000",
     monojetSel->SetCategoryActive(iCat, kTRUE);
     for (auto& name : triggerNames[iCat])
       monojetSel->AddTriggerName(iCat, name);
+    monojetSel->SetMinNumJets(iCat, 1);
     monojetSel->SetMaxNumJets(iCat, 0xffffffff);
     monojetSel->SetMaxJetEta(iCat, maxJetEta);
     monojetSel->SetMinChargedHadronFrac(iCat, 0.2); 

--- a/Skim/src/MonoJetAnalysisMod.cc
+++ b/Skim/src/MonoJetAnalysisMod.cc
@@ -112,16 +112,22 @@ MonoJetAnalysisMod::Process()
   auto* electrons = GetObject<ElectronCol>(fVetoElectronsName);
   if (!electrons)
     SendError(kAbortAnalysis, "Process", "Could not find " + fVetoElectronsName);
-  auto* electronMask = GetObject<NFArrBool>(fElectronMaskName);
-  if (!electronMask)
-    SendError(kAbortAnalysis, "Process", "Could not find " + fElectronMaskName);
+  NFArrBool* electronMask = 0;
+  if (fCategoryActive[kDielectron] || fCategoryActive[kSingleElectron]) {
+    electronMask = GetObject<NFArrBool>(fElectronMaskName);
+    if (!electronMask)
+      SendError(kAbortAnalysis, "Process", "Could not find " + fElectronMaskName);
+  }
 
   auto* muons = GetObject<MuonCol>(fVetoMuonsName);
   if (!muons)
     SendError(kAbortAnalysis, "Process", "Could not find " + fVetoMuonsName);
-  auto* muonMask = GetObject<NFArrBool>(fMuonMaskName);
-  if (!muonMask)
-    SendError(kAbortAnalysis, "Process", "Could not find " + fMuonMaskName);
+  NFArrBool* muonMask = 0;
+  if (fCategoryActive[kDimuon] || fCategoryActive[kSingleMuon]) {
+    muonMask = GetObject<NFArrBool>(fMuonMaskName);
+    if (!muonMask)
+      SendError(kAbortAnalysis, "Process", "Could not find " + fMuonMaskName);
+  }
 
   auto* taus = GetObject<PFTauCol>(fVetoTausName);
   if (!taus)
@@ -130,9 +136,12 @@ MonoJetAnalysisMod::Process()
   auto* photons = GetObject<PhotonCol>(fVetoPhotonsName);
   if (!photons)
     SendError(kAbortAnalysis, "Process", "Could not find " + fVetoPhotonsName);
-  auto* photonMask = GetObject<NFArrBool>(fPhotonMaskName);
-  if (!photonMask)
-    SendError(kAbortAnalysis, "Process", "Could not find " + fPhotonMaskName);
+  NFArrBool* photonMask = 0;
+  if (fCategoryActive[kPhoton]) {
+    photonMask = GetObject<NFArrBool>(fPhotonMaskName);
+    if (!photonMask)
+      SendError(kAbortAnalysis, "Process", "Could not find " + fPhotonMaskName);
+  }
 
   TriggerMask* triggerMask = 0;
   if (HasHLTInfo() && GetHltFwkMod()->HasData()) {

--- a/Skim/src/MonoJetAnalysisMod.cc
+++ b/Skim/src/MonoJetAnalysisMod.cc
@@ -31,8 +31,9 @@ MonoJetAnalysisMod::MonoJetAnalysisMod(const char *name, const char *title) :
   BaseMod(name, title)
 {
   // cuts
-  Double_t dbig = std::numeric_limits<double>::max();
+  double dbig = std::numeric_limits<double>::max();
   std::fill_n(fCategoryActive, nMonoJetCategories, false);
+  std::fill_n(fMinNumJets, nMonoJetCategories, 0xffffffff);
   std::fill_n(fMaxNumJets, nMonoJetCategories, 0);
   std::fill_n(fMinLeadJetPt, nMonoJetCategories, dbig);
   std::fill_n(fMaxJetEta, nMonoJetCategories, 0.);
@@ -269,10 +270,12 @@ MonoJetAnalysisMod::Process()
       goodJets.push_back(&jet);
     }
 
-    if (goodJets.size() == 0 || goodJets[0]->Pt() < fMinLeadJetPt[iCat])
-      continue;
+    if (fMinNumJets[iCat] != 0) {
+      if (goodJets.size() < fMinNumJets[iCat] || goodJets[0]->Pt() < fMinLeadJetPt[iCat])
+        continue;
 
-    fCutflow[iCat]->Fill(cLeadJet);
+      fCutflow[iCat]->Fill(cLeadJet);
+    }
 
     if (goodJets.size() > fMaxNumJets[iCat])
       continue;

--- a/Skim/src/MonoJetAnalysisMod.cc
+++ b/Skim/src/MonoJetAnalysisMod.cc
@@ -41,6 +41,10 @@ MonoJetAnalysisMod::MonoJetAnalysisMod(const char *name, const char *title) :
   std::fill_n(fMinChargedHadronFrac, nMonoJetCategories, dbig);
   std::fill_n(fMaxNeutralHadronFrac, nMonoJetCategories, 0.);
   std::fill_n(fMaxNeutralEmFrac, nMonoJetCategories, 0.);
+  std::fill_n(fVetoElectrons, nMonoJetCategories, true);
+  std::fill_n(fVetoMuons, nMonoJetCategories, true);
+  std::fill_n(fVetoTaus, nMonoJetCategories, true);
+  std::fill_n(fVetoPhotons, nMonoJetCategories, true);
 
   fCategoryFlags.Resize(nMonoJetCategories);
 }
@@ -189,7 +193,7 @@ MonoJetAnalysisMod::Process()
         continue;
       break;
     default:
-      if (electrons->GetEntries() != 0)
+      if (fVetoElectrons[iCat] && electrons->GetEntries() != 0)
         continue;
       break;
     }
@@ -206,14 +210,14 @@ MonoJetAnalysisMod::Process()
         continue;
       break;
     default:
-      if (muons->GetEntries() != 0)
+      if (fVetoMuons[iCat] && muons->GetEntries() != 0)
         continue;
       break;
     }
 
     fCutflow[iCat]->Fill(cNMuons);
 
-    if (taus->GetEntries() != 0)
+    if (fVetoTaus[iCat] && taus->GetEntries() != 0)
       continue;
 
     fCutflow[iCat]->Fill(cNTaus);
@@ -224,7 +228,7 @@ MonoJetAnalysisMod::Process()
         continue;
       break;
     default:
-      if (photons->GetEntries() != 0)
+      if (fVetoPhotons[iCat] && photons->GetEntries() != 0)
         continue;
       break;
     };


### PR DESCRIPTION
GoodPVMod: Was plotting MC vertex info, but this is done already in AnaFwkMod. Guillelmo wanted it removed from GoodPVMod. Besides, it was somewhat weird that a PV selection module would have an IsMC switch (and was often forgotten, causing crashes).

MetCorrectionMod: Now publishing an Array of Met so that the corrected Met can be written to a file. Minor chance that this causes problems downstream, but as long as a Collection (which is a base class of Array and ObjArray) is requested, the change is transparent.

MonoJetSkimMod: some more switches, basically to treat the dilepton control region differently from the others. List of branches to keep in runMonoJetSkim was revised.
