### PR TITLE
for performance and code readability

### DIFF
--- a/Mods/interface/PuppiMod.h
+++ b/Mods/interface/PuppiMod.h
@@ -10,9 +10,9 @@
 #define MITPHYSICS_MODS_PUPPIMOD_H
 
 #include "MitAna/TreeMod/interface/BaseMod.h" 
-#include "MitAna/DataTree/interface/VertexCol.h"
-#include "MitAna/DataTree/interface/PFCandidateCol.h"
-#include "MitAna/DataCont/interface/Types.h"
+#include "MitAna/DataTree/interface/VertexFwd.h"
+#include "MitAna/DataTree/interface/PFCandidateFwd.h"
+#include "MitPhysics/Utils/interface/ParticleMapper.h"
 
 namespace mithep 
 {
@@ -22,10 +22,6 @@ namespace mithep
       PuppiMod( const char *name="PuppiMod", 
                 const char *title="Puppi module" );
      ~PuppiMod();
-
-      Int_t GetParticleType( const PFCandidate *cand );
-      Int_t GetEtaBin( const PFCandidate *cand );
-      Double_t Chi2fromDZ( Double_t dz );
 
       const char   *GetVertexesName()              const     { return fVertexesName;           }
       const char   *GetInputName()                 const     { return fPFCandidatesName;       }   
@@ -57,17 +53,26 @@ namespace mithep
       void SetDump( Bool_t dump )                            { fDumpingPuppi = dump;           }
 
     protected:
-      void                  SlaveBegin();
-      void                  SlaveTerminate();
-      void                  Process();
+      void                  SlaveBegin() override;
+      void                  SlaveTerminate() override;
+      void                  Process() override;
+
+      enum ParticleType {
+        kChargedPrimary = 1,
+        kChargedPU,
+        kNeutralCentral,
+        kNeutralForward
+      };
+
+      ParticleType GetParticleType( const PFCandidate *cand, Vertex const* ) const;
+      Int_t GetEtaBin( const PFCandidate *cand ) const;
+      Double_t Chi2fromDZ( Double_t dz ) const;
       
       TString               fEtaConfigName;          // Name of the configuration file with eta tables
       TString               fVertexesName;           // Name of vertices collection used for PV
       TString               fPFCandidatesName;       // Name of PFCandidate collection (input)
       TString               fPuppiParticlesName;     // Name of Puppi Particle collection (output)
 
-      const VertexCol      *fVertexes;               // Vertex branch
-      const PFCandidateCol *fPFCandidates;           // Particle flow branch
       PFCandidateArr       *fPuppiParticles;         // The output collection for publishing
 
       Double_t fRMin;                                // Minimum dR cut for summing up surrounding particles
@@ -92,7 +97,7 @@ namespace mithep
       Bool_t   fDumpingPuppi;                        // If this is true, we dump particle information and weights
 
       // These are parameters that are functions of Eta hopefully we can be more clever some day
-      Int_t fNumEtaBins;                             // This is the number of eta regions we are dividing into
+      UInt_t fNumEtaBins;                             // This is the number of eta regions we are dividing into
       std::vector<Double_t> fMaxEtas;                // These are the maximum etas for each region of the table
       std::vector<Double_t> fMinPts;                 // Various Pt cuts
       std::vector<Double_t> fMinNeutralPts;          // Minimum Pt cut on neutral particles (after weighting)
@@ -100,6 +105,8 @@ namespace mithep
       std::vector<Double_t> fRMSEtaSFs;              // Scale factor for RMS as function of Eta
       std::vector<Double_t> fMedEtaSFs;              // Scale factor for median as a function of Eta
       std::vector<Double_t> fEtaMaxExtraps;          // I think this is the maximum eta to calculate median alphas?
+
+      ParticleMapper* fMapper;                        // For efficient determination of particle proximity
 
       ClassDef(PuppiMod, 1)                          // Puppi module
   };

--- a/Mods/src/PuppiMod.cc
+++ b/Mods/src/PuppiMod.cc
@@ -3,8 +3,9 @@
 
 #include "MitPhysics/Mods/interface/PuppiMod.h"
 #include "MitCommon/MathTools/interface/MathUtils.h"
-#include "MitPhysics/Init/interface/ModNames.h"
-#include "MitPhysics/Utils/interface/ParticleMapper.h"
+#include "MitAna/DataTree/interface/Names.h"
+#include "MitAna/DataTree/interface/PFCandidateCol.h"
+#include "MitAna/DataTree/interface/VertexCol.h"
 
 #include "TSystem.h"
 #include "Math/QuantFuncMathCore.h"
@@ -15,13 +16,12 @@ using namespace mithep;
 ClassImp(mithep::PuppiMod)
 
 //--------------------------------------------------------------------------------------------------
-PuppiMod::PuppiMod(const char *name, const char *title) : 
+PuppiMod::PuppiMod(const char *name, const char *title) :
   BaseMod(name,title),
   fEtaConfigName(""),
   fVertexesName(Names::gkPVBrn),
   fPFCandidatesName(Names::gkPFCandidatesBrn),
   fPuppiParticlesName("PuppiParticles"),
-  fPFCandidates(0),
   fPuppiParticles(0),
   fRMin(0.02),
   fR0(0.3),
@@ -38,53 +38,62 @@ PuppiMod::PuppiMod(const char *name, const char *title) :
   fApplyLowPUCorr(kTRUE),
   fUseEtaForAlgo(kTRUE),
   fEtaForAlgo(2.5),
-  fDumpingPuppi(kFALSE)
+  fDumpingPuppi(kFALSE),
+  fMapper(0)
 {
   // Constructor.
 }
 
 //--------------------------------------------------------------------------------------------------
-PuppiMod::~PuppiMod() {} 
+PuppiMod::~PuppiMod()
+{
+}
 
 //--------------------------------------------------------------------------------------------------
-Int_t PuppiMod::GetParticleType(const PFCandidate *cand)
+PuppiMod::ParticleType
+PuppiMod::GetParticleType(const PFCandidate *cand, Vertex const* pv) const
 {
-  Bool_t charged = (cand->PFType() > 0 && cand->PFType() < 4);
+  auto pfType = cand->PFType();
+  Bool_t charged = (pfType == PFCandidate::eHadron || pfType == PFCandidate::eElectron || pfType == PFCandidate::eMuon);
+
   if (fUseEtaForAlgo) {
-    Double_t checkEta = fabs(cand->Eta());
+    Double_t checkEta = cand->AbsEta();
     if (checkEta > fEtaForAlgo)
-      return 4;
-    else if (not charged) 
-      return 3;
+      return kNeutralForward;
+    else if (not charged)
+      return kNeutralCentral;
   }
   if (charged) {
     Double_t checkDZ = 0.;
     Double_t checkD0 = 0.;
     if (cand->HasTrackerTrk()) {
-      checkDZ = cand->TrackerTrk()->DzCorrected(*(fVertexes->At(0)));
-      checkD0 = cand->TrackerTrk()->D0Corrected(*(fVertexes->At(0)));
+      checkDZ = cand->TrackerTrk()->DzCorrected(*pv);
+      checkD0 = cand->TrackerTrk()->D0Corrected(*pv);
     }
     else if (cand->HasGsfTrk()) {
-      checkDZ = cand->GsfTrk()->DzCorrected(*(fVertexes->At(0)));
-      checkD0 = cand->GsfTrk()->D0Corrected(*(fVertexes->At(0)));
+      checkDZ = cand->GsfTrk()->DzCorrected(*pv);
+      checkD0 = cand->GsfTrk()->D0Corrected(*pv);
     }
     if (fabs(checkDZ) < fDZCut && checkD0 < fD0Cut)
-      return 1;                               // This is charged PV particle
-    else return 2;                            // This is charged PU particle
+      return kChargedPrimary;  // This is charged PV particle
+    else
+      return kChargedPU;       // This is charged PU particle
   }
-  else if (cand->PFType() != 6 && cand->PFType() != 7)
-    return 3;                                 // This is neutral particle in the center
-  else return 4;                              // This is neutral particle in the for ward region
+  else if (pfType != PFCandidate::eHadronHF && pfType != PFCandidate::eEGammaHF)
+    return kNeutralCentral;    // This is neutral particle in the center
+  else
+    return kNeutralForward;    // This is neutral particle in the forward region
 }
 
 //--------------------------------------------------------------------------------------------------
-Int_t PuppiMod::GetEtaBin(const PFCandidate *cand)
+Int_t
+PuppiMod::GetEtaBin(const PFCandidate *cand) const
 {
   Int_t etaBin = -1;
-  Double_t checkEta = fabs(cand->Eta());
-  for (Int_t i0 = 0; i0 < fNumEtaBins; i0++) {
-    if (checkEta < fMaxEtas[i0]) {
-      etaBin = i0;                            // This relies on putting the eta bins
+  Double_t checkEta = cand->AbsEta();
+  for (UInt_t iEtaBin = 0; iEtaBin < fNumEtaBins; iEtaBin++) {
+    if (checkEta < fMaxEtas[iEtaBin]) {
+      etaBin = iEtaBin;                            // This relies on putting the eta bins
       break;                                  //   in increasing order
     }
   }
@@ -92,33 +101,43 @@ Int_t PuppiMod::GetEtaBin(const PFCandidate *cand)
 }
 
 //--------------------------------------------------------------------------------------------------
-Double_t PuppiMod::Chi2fromDZ(Double_t dz)
+Double_t
+PuppiMod::Chi2fromDZ(Double_t dz) const
 {
   Double_t probPV = ROOT::Math::normal_cdf_c(fabs(dz),fTrackUncertainty) * 2.0;
   Double_t probPU = 1 - probPV;
   Double_t chi = 0;
-  if (probPU == 1) 
+  if (probPU == 1)
     chi = 100;                                // This doesn't exactly match CMSSW, but I like this better
-  else 
+  else
     chi = TMath::ChisquareQuantile(probPU,1);
-  return pow(chi,2);
+  return chi * chi;
 }
 
 //--------------------------------------------------------------------------------------------------
-void PuppiMod::SlaveBegin()
+void
+PuppiMod::SlaveBegin()
 {
+  // Read the configuration file
+  if (fEtaConfigName == "") {
+    SendError(kAbortAnalysis, "SlaveBegin", "Config name for Puppi not given.");
+    return;
+  }
+
   // Prepare the storage array for the PuppiParticles
   fPuppiParticles = new PFCandidateArr(16);
   fPuppiParticles->SetName(fPuppiParticlesName);
   PublishObj(fPuppiParticles);
 
-  // Read the configuration file
-  if (fEtaConfigName == "")
-    SendError(kAbortAnalysis, "SlaveBegin", "Config name for Puppi not given.");
+  Info("SlaveBegin", "Reading PUPPI config file " + fEtaConfigName);
 
-  std::cout << fEtaConfigName << std::endl;
   std::ifstream configFile;
   configFile.open(fEtaConfigName.Data());
+  if (!configFile.is_open()) {
+    SendError(kAbortAnalysis, "SlaveBegin", "Config file %s could not be opened.", fEtaConfigName.Data());
+    return;
+  }
+
   TString tempMaxEta;
   TString tempMinPt;
   TString tempMinNeutralPt;
@@ -141,235 +160,222 @@ void PuppiMod::SlaveBegin()
     }
   }
   fNumEtaBins = fMaxEtas.size();
-  std::cout << "Number of Eta bins: " << fNumEtaBins << std::endl;
+  Info("SlaveBegin", "Number of Eta bins: %d", fNumEtaBins);
+
+  fMapper = new ParticleMapper(fR0, fR0, fMaxEtas[fNumEtaBins-1]);
 }
 
 //--------------------------------------------------------------------------------------------------
-void PuppiMod::SlaveTerminate()
+void
+PuppiMod::SlaveTerminate()
 {
   // ===== deallocate memory ====
-  // Or you know, don't
+  delete fPuppiParticles;
+  delete fMapper;
 }
 
 //--------------------------------------------------------------------------------------------------
-void PuppiMod::Process()
+void
+PuppiMod::Process()
 {
-  // Process entries of the tree. 
-  fVertexes = GetObject<VertexCol>(fVertexesName);
-  fPFCandidates = GetObject<PFCandidateCol>(fPFCandidatesName);
+  // Process entries of the tree.
+  auto* vertexes = GetObject<VertexCol>(fVertexesName);
+  if (!vertexes)
+    SendError(kAbortAnalysis, "Process", "PV collection not found");
 
-  PFCandidateArr *PuppiParticles = new PFCandidateArr;        // This array is only used if adding object to event, not publishing
+  auto* pv = vertexes->At(0);
+
+  auto* pfCandidates = GetObject<PFCandidateCol>(fPFCandidatesName);
 
   if (fDumpingPuppi) {
-    std::cout << "Primary Vertex location: " << fVertexes->At(0)->Position().x() << ", ";
-    std::cout << fVertexes->At(0)->Position().y() << ", " << fVertexes->At(0)->Position().z() << std::endl;
+    std::cout << "Primary Vertex location: " << pv->Position().x() << ", ";
+    std::cout << pv->Position().y() << ", " << pv->Position().z() << std::endl;
   }
 
   // This mapper will return particles that are only close in eta, phi space
-  ParticleMapper *Mapper = new ParticleMapper();
-  Mapper->Initialize(*fPFCandidates,fR0,fR0,fMaxEtas[fNumEtaBins-1]);
+  fMapper->InitEvent(*pfCandidates);
 
-  const Int_t numCandidates = fPFCandidates->GetEntries();
-  Double_t alphaF[numCandidates];                             // This is alpha(F) of all particles for particle i
-  Double_t alphaC[numCandidates];                             // This is alpha(C) of charged PV for particle i
-  Int_t IndicesF[numCandidates];                              // A bunch of indices used for sorting
-  Int_t IndicesC[numCandidates];
-  Int_t numCHPU[fNumEtaBins];                                 // Track the number of particles that are charged PU for eta bin
-  Int_t numFCHPUis0[fNumEtaBins];                             // Number of alphas to ignore when finding the median for each
-  Int_t numCCHPUis0[fNumEtaBins];                             //   eta bin
-  Double_t alphaFCHPU[fNumEtaBins][numCandidates];            // This is alphaF for charged PU particles for eta bin
-  Double_t alphaCCHPU[fNumEtaBins][numCandidates];            // This is alphaC for charged PU particles for eta bin
-  Int_t IndicesFCHPU[fNumEtaBins][numCandidates];
-  Int_t IndicesCCHPU[fNumEtaBins][numCandidates];
+  UInt_t numCandidates = pfCandidates->GetEntries();
+  std::vector<Double_t> alphaF(numCandidates, 0.);                             // This is alpha(F) of all particles for particle i
+  std::vector<Double_t> alphaC(numCandidates, 0.);                             // This is alpha(C) of charged PV for particle i
+  std::vector<UInt_t> numFCHPUis0(fNumEtaBins, 0);                             // Number of alphas to ignore when finding the median for each
+  std::vector<UInt_t> numCCHPUis0(fNumEtaBins, 0);                             //   eta bin
+  std::vector<std::vector<Double_t>> alphaFCHPU(fNumEtaBins);            // This is alphaF for charged PU particles for eta bin
+  std::vector<std::vector<Double_t>> alphaCCHPU(fNumEtaBins);            // This is alphaC for charged PU particles for eta bin
+  std::vector<std::vector<Double_t>> alphaFCHPV(fNumEtaBins);            // This is alphaF for charged PV particles for eta bin
+  std::vector<std::vector<Double_t>> alphaCCHPV(fNumEtaBins);            // This is alphaC for charged PV particles for eta bin
 
-  Int_t numCHPV[fNumEtaBins];                                 // Track the number of particles that are charged PV for eta bin
-  Double_t alphaFCHPV[fNumEtaBins][numCandidates];            // This is alphaF for charged PV particles for eta bin
-  Double_t alphaCCHPV[fNumEtaBins][numCandidates];            // This is alphaC for charged PV particles for eta bin
-
-  for (Int_t i0 = 0; i0 < fNumEtaBins; i0++) {                // Initialize these for counting
-    numCHPU[i0] = 0;
-    numFCHPUis0[i0] = 0;
-    numCCHPUis0[i0] = 0;
-    numCHPV[i0] = 0;
-  }
-
-  for (Int_t i0 = 0; i0 < numCandidates; i0++) {
-    const PFCandidate *iCandidate = fPFCandidates->At(i0);
-      
-    // Initialize alphas and indices for sorting
-    alphaF[i0] = 0;
-    alphaC[i0] = 0;
-    IndicesF[i0] = i0;
-    IndicesC[i0] = i0;
+  for (UInt_t iCand = 0; iCand < numCandidates; iCand++) {
+    const PFCandidate *iCandidate = pfCandidates->At(iCand);
 
     Int_t etaBin = GetEtaBin(iCandidate);
-    if (etaBin < 0) 
+    if (etaBin < 0)
       continue;
-    if (iCandidate->Pt() < fMinPts[etaBin]) 
+    if (iCandidate->Pt() < fMinPts[etaBin])
       continue;                                               // if not meeting Pt cut, say it's PU
 
     // Determine if the PFCandidate is charged PU. This will help characterize neutral PU.
-    Int_t iParticleType = GetParticleType(iCandidate);
+    ParticleType iParticleType = GetParticleType(iCandidate, pv);
     // Mapper is getting nearby PFCandidates
-    std::vector<Int_t> nearList = Mapper->GetSurrounding(i0);
-    for (UInt_t i1 = 0; i1 < nearList.size(); i1++) {
-      Int_t i2 = nearList[i1];                                // Getting index from mapper results
-      if (i0 == i2) 
+    std::vector<UInt_t> nearList(fMapper->GetSurrounding(iCand));
+    for (UInt_t iNeighbor : nearList) {
+      if (iCand == iNeighbor)
         continue;                                             // Don't bother comparing a particle to itself
-      const PFCandidate *jCandidate = fPFCandidates->At(i2);
+
+      const PFCandidate *jCandidate = pfCandidates->At(iNeighbor);
       Double_t dRTemp = MathUtils::DeltaR(iCandidate,jCandidate);
       if (dRTemp > fRMin && dRTemp < fR0) {                                          // Only look at other particles in this range
-        Int_t jParticleType = GetParticleType(jCandidate);
+        ParticleType jParticleType = GetParticleType(jCandidate, pv);
         Double_t theAddition = (pow(jCandidate->Pt(),fAlpha))/(pow(dRTemp,fBeta));   // This is the thing we have to add inside the log
-        alphaF[i0] = alphaF[i0] + theAddition;                                       // First do the sum inside the log (alphaF)
-        if (jParticleType == 1)                                                      // if the particle is charged PV
-          alphaC[i0] = alphaC[i0] + theAddition;                                     //   add to alphaC
+        alphaF[iCand] += theAddition;                                       // First do the sum inside the log (alphaF)
+        if (jParticleType == kChargedPrimary)                                                      // if the particle is charged PV
+          alphaC[iCand] += theAddition;                                     //   add to alphaC
       }
     }
-    if (alphaF[i0] == 0) 
-      alphaF[i0] = -100;                                                             // Take the logs and ignore sum == 0 particles
-    else 
-      alphaF[i0] = TMath::Log(alphaF[i0]);
-    if (alphaC[i0] == 0) 
-      alphaC[i0] = -100;
-    else 
-      alphaC[i0] = TMath::Log(alphaC[i0]);
-    if (iParticleType == 2) {                                       // if charged PU, we might store it in the proper eta bin
+
+    if (alphaF[iCand] == 0)
+      alphaF[iCand] = -100;                                                             // Take the logs and ignore sum == 0 particles
+    else
+      alphaF[iCand] = TMath::Log(alphaF[iCand]);
+
+    if (alphaC[iCand] == 0)
+      alphaC[iCand] = -100;
+    else
+      alphaC[iCand] = TMath::Log(alphaC[iCand]);
+
+    if (iParticleType == kChargedPU) {                                       // if charged PU, we might store it in the proper eta bin
       Double_t checkEta = fabs(iCandidate->Eta());
-      for (Int_t i1 = 0; i1 < fNumEtaBins; i1++) {
-        if (checkEta > fEtaMaxExtraps[i1]) 
+      for (UInt_t iEtaBin = 0; iEtaBin < fNumEtaBins; iEtaBin++) {
+        if (checkEta > fEtaMaxExtraps[iEtaBin])
           continue;                                                 // if outside the binning that we are interested in, don't use CHPU
-        if (alphaF[i0] <= 0) 
-          numFCHPUis0[i1]++;                                        // Count particles to ignore when taking the median
-        if (alphaC[i0] <= 0)
-          numCCHPUis0[i1]++;
-        alphaFCHPU[i1][numCHPU[i1]] = alphaF[i0];                   // Only intializing particles up to the number of charged PU
-        alphaCCHPU[i1][numCHPU[i1]] = alphaC[i0];
-        numCHPU[i1]++;                                              // Count the total number of charged PU particles
+
+        if (alphaF[iCand] <= 0)
+          numFCHPUis0[iEtaBin]++;                                        // Count particles to ignore when taking the median
+
+        if (alphaC[iCand] <= 0)
+          numCCHPUis0[iEtaBin]++;
+
+        alphaFCHPU[iEtaBin].push_back(alphaF[iCand]);                   // Only intializing particles up to the number of charged PU
+        alphaCCHPU[iEtaBin].push_back(alphaC[iCand]);
       }
     }
-    else if (iParticleType == 1 && fApplyLowPUCorr) {               // if charged PV, and trying to correct
+    else if (iParticleType == kChargedPrimary && fApplyLowPUCorr) {               // if charged PV, and trying to correct
       Double_t checkEta = fabs(iCandidate->Eta());
-      for (Int_t i1 = 0; i1 < fNumEtaBins; i1++) {
-        if (checkEta > fEtaMaxExtraps[i1])
+      for (UInt_t iEtaBin = 0; iEtaBin < fNumEtaBins; iEtaBin++) {
+        if (checkEta > fEtaMaxExtraps[iEtaBin])
           continue;                                                 // if outside the binning that we are interested in, don't use CHPV
-        alphaFCHPV[i1][numCHPV[i1]] = alphaF[i0];                   // Only intializing particles up to the number of charged PV
-        alphaCCHPV[i1][numCHPV[i1]] = alphaC[i0];
-        numCHPV[i1]++;                                              // Count the total number of charged PV particles
+
+        alphaFCHPV[iEtaBin].push_back(alphaF[iCand]);                   // Only intializing particles up to the number of charged PV
+        alphaCCHPV[iEtaBin].push_back(alphaC[iCand]);
       }
     }
   }
 
-  // Set the indices for sorting for the charged PU alphas
-  for (Int_t i0 = 0; i0 < fNumEtaBins; i0++) {
-    for (Int_t i1 = 0; i1 < numCandidates; i1++) {
-      IndicesFCHPU[i0][i1] = i1;
-      IndicesCCHPU[i0][i1] = i1;
-    }
+  std::vector<UInt_t> numCHPU(fNumEtaBins);
+  std::vector<UInt_t> numCHPV(fNumEtaBins);
+  for (unsigned iEtaBin = 0; iEtaBin != fNumEtaBins; ++iEtaBin) {
+    numCHPU[iEtaBin] = alphaFCHPU[iEtaBin].size();
+    numCHPV[iEtaBin] = alphaFCHPV[iEtaBin].size();
   }
 
-  // Sort everything to find the median and drop particles faster
-  // This gives back the Indices arrays in ordered for m
-  TMath::Sort(numCandidates,alphaF,IndicesF,0);
-  TMath::Sort(numCandidates,alphaC,IndicesC,0);
-  for (Int_t i0 = 0; i0 < fNumEtaBins; i0++) {
-    TMath::Sort(numCHPU[i0],alphaFCHPU[i0],IndicesFCHPU[i0],0);
-    TMath::Sort(numCHPU[i0],alphaCCHPU[i0],IndicesCCHPU[i0],0);
+  // Sort alphas in ascending order to find the median and drop particles faster
+  for (UInt_t iEtaBin = 0; iEtaBin < fNumEtaBins; iEtaBin++) {
+    std::sort(alphaFCHPU[iEtaBin].begin(), alphaFCHPU[iEtaBin].end());
+    std::sort(alphaCCHPU[iEtaBin].begin(), alphaCCHPU[iEtaBin].end());
     if (fDumpingPuppi) {
       std::cout << "alphaCs for median: " << std::endl;
-      for (Int_t i1 = 0; i1 < numCHPU[i0]; i1++) {
-        std::cout << i1 << " (" << IndicesFCHPU[i0][i1] << "): " << alphaCCHPU[i0][IndicesCCHPU[i0][i1]] << std::endl;
-      }
+      for (Double_t alC : alphaCCHPU[iEtaBin])
+        std::cout << alC << std::endl;
       std::cout << "alphaFs for median: " << std::endl;
-      for (Int_t i1 = 0; i1 < numCHPU[i0]; i1++) {
-        std::cout << i1 << " (" << IndicesFCHPU[i0][i1] << "): " << alphaFCHPU[i0][IndicesFCHPU[i0][i1]] << std::endl;
-      }
+      for (Double_t alF : alphaFCHPU[iEtaBin])
+        std::cout << alF << std::endl;
     }
   }
 
   // Now we'll find the median and sigma (left-handed RMS) squared for each event and eta bin
-  Double_t alphaFMed[fNumEtaBins];
-  Double_t alphaCMed[fNumEtaBins];
-  Double_t sigma2F[fNumEtaBins];
-  Double_t sigma2C[fNumEtaBins];
+  std::vector<Double_t> alphaFMed(fNumEtaBins);
+  std::vector<Double_t> alphaCMed(fNumEtaBins);
+  std::vector<Double_t> sigma2F(fNumEtaBins, 0.);
+  std::vector<Double_t> sigma2C(fNumEtaBins, 0.);
 
-  for (Int_t i0 = 0; i0 < fNumEtaBins; i0++) {
-    Int_t medIndexF = (numCHPU[i0] + numFCHPUis0[i0])/2;              // These are sort of meta
-    Int_t medIndexC = (numCHPU[i0] + numCCHPUis0[i0])/2;              // Just watch how they are used...
-    if (fDumpingPuppi) 
-      std::cout << "In bin " << i0 << " using " << medIndexC << "; " << medIndexF << std::endl;
-    if (numCHPU[i0] == numFCHPUis0[i0])
-      alphaFMed[i0] = 0;
-    else if ((numCHPU[i0] - numFCHPUis0[i0]) % 2 == 0) 
-      alphaFMed[i0] = (alphaFCHPU[i0][IndicesFCHPU[i0][medIndexF - 1]] + alphaFCHPU[i0][IndicesFCHPU[i0][medIndexF]])/2;
-    else 
-      alphaFMed[i0] = alphaFCHPU[i0][IndicesFCHPU[i0][medIndexF]];
-    if (numCHPU[i0] == numCCHPUis0[i0])
-      alphaCMed[i0] = 0;
-    else if ((numCHPU[i0] - numCCHPUis0[i0]) % 2 == 0) 
-      alphaCMed[i0] = (alphaCCHPU[i0][IndicesCCHPU[i0][medIndexC - 1]] + alphaCCHPU[i0][IndicesCCHPU[i0][medIndexC]])/2;
-    else 
-      alphaCMed[i0] = alphaCCHPU[i0][IndicesCCHPU[i0][medIndexC]];
-    
+  for (UInt_t iEtaBin = 0; iEtaBin < fNumEtaBins; iEtaBin++) {
+    Int_t medIndexF = (numCHPU[iEtaBin] + numFCHPUis0[iEtaBin])/2;              // These are sort of meta
+    Int_t medIndexC = (numCHPU[iEtaBin] + numCCHPUis0[iEtaBin])/2;              // Just watch how they are used...
+    if (fDumpingPuppi)
+      std::cout << "In bin " << iEtaBin << " using " << medIndexC << "; " << medIndexF << std::endl;
+
+    if (numCHPU[iEtaBin] == numFCHPUis0[iEtaBin])
+      alphaFMed[iEtaBin] = 0;
+    else if ((numCHPU[iEtaBin] - numFCHPUis0[iEtaBin]) % 2 == 0)
+      alphaFMed[iEtaBin] = (alphaFCHPU[iEtaBin][medIndexF - 1] + alphaFCHPU[iEtaBin][medIndexF])/2;
+    else
+      alphaFMed[iEtaBin] = alphaFCHPU[iEtaBin][medIndexF];
+
+    if (numCHPU[iEtaBin] == numCCHPUis0[iEtaBin])
+      alphaCMed[iEtaBin] = 0;
+    else if ((numCHPU[iEtaBin] - numCCHPUis0[iEtaBin]) % 2 == 0)
+      alphaCMed[iEtaBin] = (alphaCCHPU[iEtaBin][medIndexC - 1] + alphaCCHPU[iEtaBin][medIndexC])/2;
+    else
+      alphaCMed[iEtaBin] = alphaCCHPU[iEtaBin][medIndexC];
+
     // Now compute the sigma2s
-    sigma2F[i0] = 0;
-    sigma2C[i0] = 0;
-    for (Int_t i1 = numFCHPUis0[i0]; i1 < medIndexF; i1++) 
-      sigma2F[i0] = sigma2F[i0] + pow((alphaFMed[i0]-alphaFCHPU[i0][IndicesFCHPU[i0][i1]]),2);
-    sigma2F[i0] = sigma2F[i0]/(medIndexF - numFCHPUis0[i0]);
-    for (Int_t i1 = numCCHPUis0[i0]; i1 < medIndexC; i1++) 
-      sigma2C[i0] = sigma2C[i0] + pow((alphaCMed[i0]-alphaCCHPU[i0][IndicesCCHPU[i0][i1]]),2);
-    sigma2C[i0] = sigma2C[i0]/(medIndexC - numCCHPUis0[i0]);
-    
-    alphaFMed[i0] = alphaFMed[i0] * (fMedEtaSFs[i0]);                 // Scale the medians
-    alphaCMed[i0] = alphaCMed[i0] * (fMedEtaSFs[i0]);
+    for (Int_t iAlpha = numFCHPUis0[iEtaBin]; iAlpha < medIndexF; iAlpha++)
+      sigma2F[iEtaBin] += pow((alphaFMed[iEtaBin]-alphaFCHPU[iEtaBin][iAlpha]),2);
 
-    sigma2F[i0] = sigma2F[i0] * (fRMSScaleFactor) * (fRMSEtaSFs[i0]); // Scale the sigmas
-    sigma2C[i0] = sigma2C[i0] * (fRMSScaleFactor) * (fRMSEtaSFs[i0]);
+    // FIXME medIndexF can be == numFCHPUis0[iEtaBin]
+    sigma2F[iEtaBin] /= (medIndexF - numFCHPUis0[iEtaBin]);
+
+    for (Int_t iAlpha = numCCHPUis0[iEtaBin]; iAlpha < medIndexC; iAlpha++)
+      sigma2C[iEtaBin] += pow((alphaCMed[iEtaBin]-alphaCCHPU[iEtaBin][iAlpha]),2);
+
+    // FIXME the same here, potential division by 0
+    sigma2C[iEtaBin] /= (medIndexC - numCCHPUis0[iEtaBin]);
+
+    alphaFMed[iEtaBin] *= fMedEtaSFs[iEtaBin];                 // Scale the medians
+    alphaCMed[iEtaBin] *= fMedEtaSFs[iEtaBin];
+
+    sigma2F[iEtaBin] *= fRMSScaleFactor * fRMSEtaSFs[iEtaBin]; // Scale the sigmas
+    sigma2C[iEtaBin] *= fRMSScaleFactor * fRMSEtaSFs[iEtaBin];
 
     if (fApplyLowPUCorr) {                                            // if we're applying LowPUCorr
-      Int_t NumCorrF = 0;
-      Int_t NumCorrC = 0;
-      for (Int_t i1 = 0; i1 < numCHPV[i0]; i1++) {                    //   count PV that are less than median
-        if (alphaFCHPV[i0][i1] < alphaFMed[i0])
-          NumCorrF++;
-        if (alphaCCHPV[i0][i1] < alphaCMed[i0])
-          NumCorrC++;
+      Double_t NumCorrF = 0.;
+      Double_t NumCorrC = 0.;
+      for (UInt_t iCHPV = 0; iCHPV < numCHPV[iEtaBin]; iCHPV++) {                    //   count PV that are less than median
+        if (alphaFCHPV[iEtaBin][iCHPV] < alphaFMed[iEtaBin])
+          NumCorrF += 1.;
+        if (alphaCCHPV[iEtaBin][iCHPV] < alphaCMed[iEtaBin])
+          NumCorrC += 1.;
       }
-      alphaFMed[i0] = alphaFMed[i0] 
-        - sqrt(ROOT::Math::chisquared_quantile(double(NumCorrF)/
-                                               double(numCHPV[i0] + numCHPU[i0] - numFCHPUis0[i0]),
-                                               1.)
-               *sigma2F[i0]);
-      alphaCMed[i0] = alphaCMed[i0] 
-        - sqrt(ROOT::Math::chisquared_quantile(double(NumCorrC)/
-                                               double(numCHPV[i0] + numCHPU[i0] - numCCHPUis0[i0]),
-                                               1.)
-               *sigma2C[i0]);
+      Double_t quantF = ROOT::Math::chisquared_quantile(NumCorrF / double(numCHPV[iEtaBin] + numCHPU[iEtaBin] - numFCHPUis0[iEtaBin]), 1.);
+      Double_t quantC = ROOT::Math::chisquared_quantile(NumCorrC / double(numCHPV[iEtaBin] + numCHPU[iEtaBin] - numFCHPUis0[iEtaBin]), 1.);
+      alphaFMed[iEtaBin] -= sqrt(quantF * sigma2F[iEtaBin]);
+      alphaCMed[iEtaBin] -= sqrt(quantC * sigma2C[iEtaBin]);
     }
   }
 
   fPuppiParticles->Delete();
 
-  for (Int_t i0 = 0; i0 < numCandidates; i0++) {
+  for (UInt_t iCand = 0; iCand < numCandidates; iCand++) {
+    auto* cand = pfCandidates->At(iCand);
+
     // Now we are going to assign the weights
     Double_t chi2 = 0;
     Double_t weight = 0;
-    Int_t CandidateType = GetParticleType(fPFCandidates->At(i0));
-    Int_t etaBin = GetEtaBin(fPFCandidates->At(i0));
+    ParticleType CandidateType = GetParticleType(cand, pv);
+    Int_t etaBin = GetEtaBin(cand);
 
     // if charged PV with CHS, the weight is 1
-    if (fApplyCHS && CandidateType == 1)
+    if (fApplyCHS && CandidateType == kChargedPrimary)
       weight = 1;
     // if neutral central or not CHS, get central chi2
-    else if (CandidateType == 3 || (not fApplyCHS && (CandidateType == 1 || CandidateType == 2))) {
-      if (alphaC[i0] > alphaCMed[etaBin])
-        chi2 = pow((alphaC[i0] - alphaCMed[etaBin]),2)/sigma2C[etaBin];
+    else if (CandidateType == kNeutralCentral || (!fApplyCHS && (CandidateType == kChargedPrimary || CandidateType == kChargedPU))) {
+      if (alphaC[iCand] > alphaCMed[etaBin])
+        chi2 = pow((alphaC[iCand] - alphaCMed[etaBin]),2)/sigma2C[etaBin];
     }
     // if for ward particle, get for ward chi2
-    else if (CandidateType == 4) {
-      if (alphaF[i0] > alphaFMed[etaBin])
-        chi2 = pow((alphaF[i0] - alphaFMed[etaBin]),2)/sigma2F[etaBin];
+    else if (CandidateType == kNeutralForward) {
+      if (alphaF[iCand] > alphaFMed[etaBin])
+        chi2 = pow((alphaF[iCand] - alphaFMed[etaBin]),2)/sigma2F[etaBin];
     }
 
     if (chi2 > 0) {                                                    // if chi2 value was assigned
@@ -378,65 +384,69 @@ void PuppiMod::Process()
         weight = 0;                                                    // if less than the minimum cut, set weight back to zero
     }
 
-    if ((CandidateType == 3 || CandidateType == 4) &&                  // if neutral Pt is less than expected for given NPV
-       (fPFCandidates->At(i0)->Pt()*(weight) < fMinNeutralPts[etaBin] + fMinNeutralPtSlopes[etaBin] * (fVertexes->GetEntries())))
+    if ((CandidateType == kNeutralCentral || CandidateType == kNeutralForward) &&                  // if neutral Pt is less than expected for given NPV
+       (cand->Pt() * weight < fMinNeutralPts[etaBin] + fMinNeutralPtSlopes[etaBin] * (vertexes->GetEntries())))
       weight = 0;                                                      //   set weight to zero
+
     if (fInvert)
-      weight = 1.0 - weight;                                           // Invert the weight here if asked for 
-    if (weight == 0 && not fKeepPileup)
+      weight = 1.0 - weight;                                           // Invert the weight here if asked for
+
+    if (weight == 0 && !fKeepPileup)
       continue;                                                        // Throw out if we're not keeping it
 
     // add PuppiParticle to the collection
     PFCandidate *PuppiParticle = fPuppiParticles->Allocate();
-    new (PuppiParticle) PFCandidate(*fPFCandidates->At(i0));
+    new (PuppiParticle) PFCandidate(*cand);
     if (fDumpingPuppi) {
       std::cout << "=========================================================================================" << std::endl;
-      std::cout << "PF Candidate Number: " << i0 << std::endl;
-      std::cout << "PF Type: " << GetParticleType(PuppiParticle) << " (" << PuppiParticle->PFType() << ")" << std::endl;
+      std::cout << "PF Candidate Number: " << iCand << std::endl;
+      std::cout << "PF Type: " << GetParticleType(PuppiParticle, pv) << " (" << PuppiParticle->PFType() << ")" << std::endl;
       if (PuppiParticle->HasTrackerTrk()) {
-        std::cout << "Vertex distances: " << PuppiParticle->TrackerTrk()->DzCorrected(*(fVertexes->At(0))) << "; ";
-        std::cout << PuppiParticle->TrackerTrk()->D0Corrected(*(fVertexes->At(0))) << std::endl;
+        std::cout << "Vertex distances: " << PuppiParticle->TrackerTrk()->DzCorrected(*pv) << "; ";
+        std::cout << PuppiParticle->TrackerTrk()->D0Corrected(*pv) << std::endl;
       }
       else if (PuppiParticle->HasGsfTrk()) {
-        std::cout << "Vertex distances: " << PuppiParticle->GsfTrk()->DzCorrected(*(fVertexes->At(0))) << "; ";
-        std::cout << PuppiParticle->GsfTrk()->D0Corrected(*(fVertexes->At(0))) << std::endl;
+        std::cout << "Vertex distances: " << PuppiParticle->GsfTrk()->DzCorrected(*pv) << "; ";
+        std::cout << PuppiParticle->GsfTrk()->D0Corrected(*pv) << std::endl;
       }
-      std::vector<Int_t> nearList = Mapper->GetSurrounding(i0);
+      std::vector<UInt_t> nearList(fMapper->GetSurrounding(iCand));
       std::cout << "Nearby PV particles: ";
-      for (UInt_t i1 = 0; i1 < nearList.size(); i1++) {
-        if (nearList[i1] == i0)
+      for (UInt_t iNeighbor : nearList) {
+        if (iNeighbor == iCand)
           continue;
-        if (GetParticleType(fPFCandidates->At(nearList[i1])) == 1)
-          std::cout << nearList[i1] << " (" << MathUtils::DeltaR(PuppiParticle->Eta(),PuppiParticle->Phi(),
-                                                                 fPFCandidates->At(nearList[i1])->Eta(),
-                                                                 fPFCandidates->At(nearList[i1])->Phi()) <<  "), ";
+
+        if (GetParticleType(pfCandidates->At(iNeighbor), pv) == kChargedPrimary)
+          std::cout << iNeighbor << " (" << MathUtils::DeltaR(PuppiParticle->Eta(),PuppiParticle->Phi(),
+                                                                 pfCandidates->At(iNeighbor)->Eta(),
+                                                                 pfCandidates->At(iNeighbor)->Phi()) <<  "), ";
       }
       std::cout << std::endl;
       std::cout << "Nearby other particles: ";
-      for (UInt_t i1 = 0; i1 < nearList.size(); i1++) {
-        if (nearList[i1] == i0) 
+      for (UInt_t iNeighbor : nearList) {
+        if (iNeighbor == iCand)
           continue;
-        if (GetParticleType(fPFCandidates->At(nearList[i1])) != 1)
-          std::cout << nearList[i1] << " (" << MathUtils::DeltaR(PuppiParticle->Eta(),PuppiParticle->Phi(),
-                                                                 fPFCandidates->At(nearList[i1])->Eta(),
-                                                                 fPFCandidates->At(nearList[i1])->Phi()) <<  "), ";
+
+        if (GetParticleType(pfCandidates->At(iNeighbor), pv) != kChargedPrimary)
+          std::cout << iNeighbor << " (" << MathUtils::DeltaR(PuppiParticle->Eta(),PuppiParticle->Phi(),
+                                                                 pfCandidates->At(iNeighbor)->Eta(),
+                                                                 pfCandidates->At(iNeighbor)->Phi()) <<  "), ";
       }
       std::cout << std::endl;
-      nearList.resize(0);
+
       std::cout << "Pt: " << PuppiParticle->Pt() << "; Eta: " << PuppiParticle->Eta();
       std::cout << "; Phi: " << PuppiParticle->Phi() << "; Mass: " << PuppiParticle->Mass() << std::endl;
       std::cout << "Median Alphas:";
       std::cout << alphaCMed[GetEtaBin(PuppiParticle)] << "; " << alphaFMed[GetEtaBin(PuppiParticle)] << std::endl;
       std::cout << "Alpha RMS:";
       std::cout << sigma2C[GetEtaBin(PuppiParticle)] << "; " << sigma2F[GetEtaBin(PuppiParticle)] << std::endl;
-      std::cout << "Weight: " << weight << "; " << alphaC[i0] << "; " << alphaF[i0] << std::endl;
+      std::cout << "Weight: " << weight << "; " << alphaC[iCand] << "; " << alphaF[iCand] << std::endl;
       fDumpingPuppi = false;                                           // You will not want to dump this more than once
     }
+
     if (weight < 1)                                                    // Weight the particle if required
       PuppiParticle->SetPtEtaPhiM(PuppiParticle->Pt()*(weight),PuppiParticle->Eta(),
                                   PuppiParticle->Phi(),PuppiParticle->Mass()*(weight));
   }
+
   fPuppiParticles->Trim();
-  PuppiParticles->Clone();
-  AddObjThisEvt(PuppiParticles);
 }

--- a/Utils/interface/ParticleMapper.h
+++ b/Utils/interface/ParticleMapper.h
@@ -21,27 +21,26 @@ namespace mithep {
   class ParticleMapper {
   public:
 
-    ParticleMapper();
+    ParticleMapper(Double_t DeltaEta = 0.3,Double_t DeltaPhi = 0.3,Double_t EtaMax = 5.0);
     virtual ~ParticleMapper();
 
-    void Initialize(const PFCandidateCol &Particles,Double_t DeltaEta = 0.3,Double_t DeltaPhi = 0.3,Double_t EtaMax = 5.0);
+    void InitEvent(const PFCandidateCol &);
     
-    std::vector<Int_t> GetSurrounding( Int_t index );                // Returns a vector of particle indices in particle bin and adjacent bins
-    std::vector<Int_t> GetNearEtaPhi( Double_t eta, Double_t phi);   // Returns a vector of particle indices in area of eta-phi spot given
+    std::vector<UInt_t> GetSurrounding( UInt_t index ) const;                // Returns a vector of particle indices in particle bin and adjacent bins
+    std::vector<UInt_t> GetNearEtaPhi( Double_t eta, Double_t phi) const;   // Returns a vector of particle indices in area of eta-phi spot given
 
   private:
     
     Double_t  fDeltaEta;
     Double_t  fDeltaPhi;
-    Int_t     fNumParticles;
-    Int_t     fNumEtaBins;
-    Int_t     fNumPhiBins;
-    Int_t     fNumTotBins;
+    Double_t  fEtaMax;
+    UInt_t    fNumEtaBins;
+    UInt_t    fNumPhiBins;
 
-    Int_t *fParticleLocation;
-    std::vector<Int_t> *fBinContents;
+    std::vector<Int_t> fParticleLocation;          // Particle index to bin mapping
+    std::vector<std::vector<UInt_t>> fBinContents; // List of particle indices in each bin
 
-    std::vector<Int_t> ReturnNear( Int_t etaBin, Int_t phiBin );     // This is the function that the "Get" functions ultimately call
+    std::vector<UInt_t> ReturnNear( Int_t etaBin, Int_t phiBin ) const;     // This is the function that the "Get" functions ultimately call
 
     ClassDef(ParticleMapper, 0)
   };

--- a/Utils/src/ParticleMapper.cc
+++ b/Utils/src/ParticleMapper.cc
@@ -1,62 +1,52 @@
 #include "MitPhysics/Utils/interface/ParticleMapper.h"
 
+#include "TVector2.h"
+
 ClassImp(mithep::ParticleMapper)
 
 using namespace mithep;
 
 //--------------------------------------------------------------------------------------------------
-ParticleMapper::ParticleMapper() :
-  fDeltaEta(0),
-  fDeltaPhi(0),
-  fNumParticles(0),
-  fNumEtaBins(0),
-  fNumPhiBins(0),
-  fNumTotBins(0),
-  fParticleLocation(0),
-  fBinContents(0)
-{ }
+ParticleMapper::ParticleMapper(Double_t DeltaEta/* = 0.3*/, Double_t DeltaPhi/* = 0.3*/, Double_t EtaMax/* = 5.*/) :
+  fDeltaEta(DeltaEta),
+  fDeltaPhi(DeltaPhi),
+  fEtaMax(EtaMax),
+  fNumEtaBins(2*ceil(EtaMax/fDeltaEta)),
+  fNumPhiBins(floor(2*(TMath::Pi()/fDeltaPhi))),  // The last bin will be larger than fDeltaPhi
+  fParticleLocation(),
+  fBinContents(fNumEtaBins * fNumPhiBins)
+{
+}
 
 //--------------------------------------------------------------------------------------------------
 ParticleMapper::~ParticleMapper()
 {
-  delete fParticleLocation;
-  delete fBinContents;
 }
 
 //--------------------------------------------------------------------------------------------------
 void
-ParticleMapper::Initialize(const PFCandidateCol &Particles, Double_t DeltaEta, Double_t DeltaPhi, Double_t EtaMax)
+ParticleMapper::InitEvent(const PFCandidateCol &Particles)
 {
-  fDeltaEta = DeltaEta;
-  fDeltaPhi = DeltaPhi;
+  fParticleLocation.assign(Particles.GetEntries(), -1);
 
-  fNumParticles = Particles.GetEntries();
-  fNumEtaBins   = 2*ceil(EtaMax/fDeltaEta);
-  fNumPhiBins   = floor(2*(TMath::Pi()/fDeltaPhi));  // The last bin will be larger than fDeltaPhi
-  fNumTotBins   = fNumEtaBins * fNumPhiBins;
+  for (auto& cont : fBinContents)
+    cont.clear();
 
-  fParticleLocation = new Int_t[fNumParticles];
-
-  fBinContents = new std::vector<Int_t>[fNumTotBins];
-
-  for (Int_t i0 = 0; i0 < fNumTotBins; i0++)
-    fBinContents[i0].resize(0);
-
-  for (Int_t i0 = 0; i0 < fNumParticles; i0++) {
+  for (UInt_t i0 = 0; i0 < fParticleLocation.size(); i0++) {
     Int_t etaBin;
     Int_t phiBin;
     Double_t eta = Particles.At(i0)->Eta();
-    if (fabs(eta) > EtaMax) {
-      fParticleLocation[i0] = -1;
+    if (fabs(eta) > fEtaMax)
       continue;
-    }
-    Double_t phi = Particles.At(i0)->Phi();
-    if (phi < 0)
-      phi = phi + 2.0*(TMath::Pi());                // This way's easier so that there's only one bin with weird resolution
+
+    // Usng 0-2pi is easier so that there's only one bin with weird resolution
+    Double_t phi = TVector2::Phi_0_2pi(Particles.At(i0)->Phi());
+
     etaBin = floor(eta/fDeltaEta) + fNumEtaBins/2;
     phiBin = floor(phi/fDeltaPhi);
-    if (phiBin == fNumPhiBins)
+    if (phiBin == Int_t(fNumPhiBins))
       phiBin = phiBin - 1;                          // Sticks overflow into last bin
+
     Int_t finalBin = etaBin + phiBin*fNumEtaBins;
     fParticleLocation[i0] = finalBin;
     fBinContents[finalBin].push_back(i0);
@@ -64,51 +54,41 @@ ParticleMapper::Initialize(const PFCandidateCol &Particles, Double_t DeltaEta, D
 }
 
 //--------------------------------------------------------------------------------------------------
-std::vector<Int_t>
-ParticleMapper::GetSurrounding(Int_t index)
+std::vector<UInt_t>
+ParticleMapper::GetSurrounding(UInt_t index) const
 {
-  if (fParticleLocation[index] < 0) {
-    std::vector<Int_t> blankVector;
-    blankVector.resize(0);
-    return blankVector;
-  }
+  if (index >= fParticleLocation.size() || fParticleLocation[index] < 0)
+    return {};
 
   Int_t bin = fParticleLocation[index];
   Int_t etaBin = bin % fNumEtaBins;
-  Int_t phiBin = bin/fNumEtaBins;
+  Int_t phiBin = bin / fNumEtaBins;
 
   return ReturnNear(etaBin, phiBin);
 }
 
 //--------------------------------------------------------------------------------------------------
-std::vector<Int_t>
-ParticleMapper::GetNearEtaPhi(Double_t eta, Double_t phi)
+std::vector<UInt_t>
+ParticleMapper::GetNearEtaPhi(Double_t eta, Double_t phi) const
 {
-  if (fabs(eta) > fDeltaEta*(fNumEtaBins/2)) {
-    std::vector<Int_t> blankVector;
-    blankVector.resize(0);
-    return blankVector;
-  }
+  if (fabs(eta) > fDeltaEta*(fNumEtaBins/2))
+    return {};
 
-  while (phi > 2*(TMath::Pi()))
-    phi = phi - 2*(TMath::Pi());
-  while (phi < 0) 
-    phi = phi + 2*(TMath::Pi());
+  phi = TVector2::Phi_0_2pi(phi);
 
   Int_t etaBin = floor(eta/fDeltaEta) + fNumEtaBins/2;
   Int_t phiBin = floor(phi/fDeltaPhi);
-  if (phiBin == fNumPhiBins) 
+  if (phiBin == Int_t(fNumPhiBins))
     phiBin = phiBin - 1;
 
   return ReturnNear(etaBin, phiBin);
 }
 
 //--------------------------------------------------------------------------------------------------
-std::vector<Int_t>
-ParticleMapper::ReturnNear(Int_t etaBin, Int_t phiBin)
+std::vector<UInt_t>
+ParticleMapper::ReturnNear(Int_t etaBin, Int_t phiBin) const
 {
-  std::vector<Int_t> tempVec;
-  tempVec.resize(0);
+  std::vector<UInt_t> tempVec;
 
   Int_t tempEtaBin;
   Int_t tempPhiBin;
@@ -116,13 +96,14 @@ ParticleMapper::ReturnNear(Int_t etaBin, Int_t phiBin)
 
   for (Int_t i0 = -1; i0 < 2; i0++) {
     tempEtaBin = etaBin + i0;
-    if (tempEtaBin < 0 || tempEtaBin >= fNumEtaBins) 
+    if (tempEtaBin < 0 || tempEtaBin >= Int_t(fNumEtaBins))
       continue;
+
     for (Int_t i1 = -1; i1 < 2; i1++) {
       tempPhiBin = phiBin + i1;
-      if (tempPhiBin == -1) 
+      if (tempPhiBin == -1)
         tempPhiBin = fNumPhiBins - 1;               // This allows wrapping
-      if (tempPhiBin == fNumPhiBins)
+      if (tempPhiBin == Int_t(fNumPhiBins))
         tempPhiBin = 0;
       tempBin = tempEtaBin + tempPhiBin*fNumEtaBins;
       tempVec.insert(tempVec.end(),fBinContents[tempBin].begin(),fBinContents[tempBin].end());


### PR DESCRIPTION
See inline comments too. Here are some general comments:
- Arrays versus vectors <br>
  There is nothing wrong with using vectors, and in fact most of the time it reduces the code clutter and diminishes the risk of incorrect memory management. There were in fact two improper deletion of arrays allocated through new []. The only case I can think of where a dynamically allocated array is preferable over a vector is when you deal with the address of the array elements directly (Vector can decide to reallocate the contents during resize operations and invalidate the direct pointers to its elements).
- Loop variable names <br>
  Use of variable names i0 and i1 is a very bad coding style (and needless to say "i" and "j" are even worse because you can't even replace-all). Always give variables meaningful names, even if that adds a few more seconds of typing to your work. In the code i0 corresponded to PFParticle index in one loop and eta bin index in another. That makes the code unnecessarily difficult to understand.
- Using numeric value for categorization <br>
  This is a specific comment on the particle type values used in PuppiMod, but deserves a general comment: Always use enum for categories. Don't force the people who read the code to memorize that number 1 means charged particle from PV.
- Signed versus unsigned integers <br>
  This is mostly about code readability: Give meanings to the choice of types you use. Array indices should be by definition unsigned integers, unless you want to initialize it with values like -1 and use that as a quick test whether the value is initialized. But in many cases, properly choosing the type of the variable according to how you intend to use it makes the code much more easy to understand.
- Spaces and newlines <br>
  Another comment about readability: Being picky about spacing looks OCD-ish and stupid, but it makes a HUGE difference in readability. It's all about being consistent. There weren't too many issues of this sort, but I'd say you should not add spaces around the function arguments in the class declarations, and also should add spaces between arithmetic operations.<br>
  `PuppiParticle->Pt()*(weight)` at first sight looks like there is a pointer named weight that is dereferenced (OK if you understand the syntax you'll realize that's not the case in a second). `PuppiParticle->Pt() * weight` is much more clearer.
