### PR TITLE
JEC uncertainty in JetCorrector

### DIFF
--- a/Mods/interface/JetCorrectionMod.h
+++ b/Mods/interface/JetCorrectionMod.h
@@ -43,6 +43,7 @@ namespace mithep
       void SetInputName(char const* name)            { fJetsName = name; }
       void SetRhoType(RhoUtilities::RhoType); /*DEPRECATED*/
       void SetRhoAlgo(unsigned algo)                 { fRhoAlgo = algo; }
+      void SetUncertaintySigma(Double_t s)           { fSigma = s; }
       void SetCorrector(JetCorrector*);
 
     protected:
@@ -55,6 +56,7 @@ namespace mithep
       TString       fJetsName{Names::gkPFJetBrn}; //name of jet collection (input))
       TString       fRhoBranchName{Names::gkPileupEnergyDensityBrn}; //name of pileup energy density collection
       UInt_t        fRhoAlgo = PileupEnergyDensity::kFixedGridFastjetAll;
+      Double_t      fSigma = 0.; //shift JES by fSigma * Uncertainty (needs uncertainty source)
       Bool_t        fOwnCorrector = kFALSE;
       JetCorrector* fCorrector = 0;
 

--- a/Mods/interface/MetCorrectionMod.h
+++ b/Mods/interface/MetCorrectionMod.h
@@ -61,6 +61,7 @@ namespace mithep {
     void SetExprShiftPx(const char *expr)  { MakeFormula(1, expr); }
     void SetExprShiftPy(const char *expr)  { MakeFormula(2, expr); }
     void AddJetCorrectionFromFile(char const* file);
+    void SetJESUncertaintySigma(Double_t s)    { fJESUncertaintySigma = s; }
     void SetJetCorrector(JetCorrector*);
     void SetRhoAlgo(UInt_t a)                  { fRhoAlgo = a; }
     void SetMaxEMFraction(Double_t m)          { fMaxEMFraction = m; }
@@ -94,6 +95,7 @@ namespace mithep {
     Bool_t        fOwnJetCorrector = kFALSE;
     JetCorrector* fJetCorrector = 0; //For type 1 correction. Can be created internally or set externally
     UInt_t        fRhoAlgo = PileupEnergyDensity::kFixedGridFastjetAll;
+    Double_t      fJESUncertaintySigma = 0.;
 
     Double_t      fMaxEMFraction = -1.; //maximum charged + neutral EM energy fraction
                                         //for jet to be in Type1 corr (< 0 -> does not skip jets)

--- a/Mods/src/JetCorrectionMod.cc
+++ b/Mods/src/JetCorrectionMod.cc
@@ -133,6 +133,7 @@ JetCorrectionMod::MakeCorrector()
 {
   if (!fCorrector) {
     fCorrector = new JetCorrector;
+    fCorrector->SetUncertaintySigma(fSigma);
     fOwnCorrector = true;
   }
 }

--- a/Mods/src/MetCorrectionMod.cc
+++ b/Mods/src/MetCorrectionMod.cc
@@ -239,14 +239,14 @@ MetCorrectionMod::Process()
       double offsetCorr;
       if (inJet.AbsEta() < 9.9) {
         std::vector<float>&& corr(fJetCorrector->CorrectionFactors(inJet, rho));
-        fullCorr = corr.back();
+        fullCorr = corr.back() * fJetCorrector->UncertaintyFactor(inJet);
         offsetCorr = corr.front();
       }
       else {
-        auto* modJet = inJet.MakeCopy();
-        modJet->SetRawPtEtaPhiM(inJetRawMom.Pt(), inJet.Eta() / inJet.AbsEta() * 9.9, inJetRawMom.Phi(), inJetRawMom.M());
-        std::vector<float>&& corr(fJetCorrector->CorrectionFactors(*modJet, rho));
-        fullCorr = corr.back();
+        auto modJet(inJet);
+        modJet.SetRawPtEtaPhiM(inJetRawMom.Pt(), inJet.Eta() / inJet.AbsEta() * 9.9, inJetRawMom.Phi(), inJetRawMom.M());
+        std::vector<float>&& corr(fJetCorrector->CorrectionFactors(modJet, rho));
+        fullCorr = corr.back() * fJetCorrector->UncertaintyFactor(modJet);
         offsetCorr = corr.front();
       }
 
@@ -355,6 +355,7 @@ MetCorrectionMod::MakeJetCorrector()
 {
   if (!fJetCorrector) {
     fJetCorrector = new JetCorrector;
+    fJetCorrector->SetUncertaintySigma(fJESUncertaintySigma);
     fOwnJetCorrector = true;
   }
 }

--- a/Utils/interface/JetCorrector.h
+++ b/Utils/interface/JetCorrector.h
@@ -29,6 +29,7 @@ namespace mithep {
     void AddParameterFile(char const* fileName);
     void ClearParameters();
     void SetMaxCorrLevel(mithep::Jet::ECorr m) { fMaxCorrLevel = m; }
+    void SetUncertaintySigma(Int_t s) { fSigma = s; }
     void Initialize();
 
     std::vector<mithep::Jet::ECorr> const& GetLevels() const { return fLevels; }
@@ -45,10 +46,11 @@ namespace mithep {
     static mithep::Jet::ECorr TranslateLevel(char const* levelName);
 
   private:
-    std::vector<JetCorrectorParameters> fParameters = {};
-    std::vector<mithep::Jet::ECorr> fLevels = {};
+    std::vector<JetCorrectorParameters> fParameters{};
+    std::vector<mithep::Jet::ECorr> fLevels{};
     mithep::Jet::ECorr fMaxCorrLevel = mithep::Jet::nECorrs;
     FactorizedJetCorrector* fCorrector = 0;
+    Int_t fSigma = 0;
 
     ClassDef(JetCorrector, 0)
   };

--- a/Utils/interface/JetCorrector.h
+++ b/Utils/interface/JetCorrector.h
@@ -18,6 +18,7 @@
 #include <algorithm>
 
 class FactorizedJetCorrector;
+class JetCorrectionUncertainty;
 
 namespace mithep {
 
@@ -29,7 +30,7 @@ namespace mithep {
     void AddParameterFile(char const* fileName);
     void ClearParameters();
     void SetMaxCorrLevel(mithep::Jet::ECorr m) { fMaxCorrLevel = m; }
-    void SetUncertaintySigma(Int_t s) { fSigma = s; }
+    void SetUncertaintySigma(Double_t s) { fSigma = s; }
     void Initialize();
 
     std::vector<mithep::Jet::ECorr> const& GetLevels() const { return fLevels; }
@@ -38,10 +39,12 @@ namespace mithep {
     std::vector<Float_t> CorrectionFactors(mithep::Jet&, Double_t rho = 0.) const;
     // Returns the full correction (i.e. the last element of CorrectionFactors)
     Float_t CorrectionFactor(mithep::Jet&, Double_t rho = 0.) const;
-    void Correct(mithep::Jet&, Double_t rho = 0.) const;
-    Bool_t IsInitialized() const { return fCorrector != 0; }
+    Float_t UncertaintyFactor(mithep::Jet&) const;
+    Bool_t IsInitialized() const;
     Bool_t IsEnabled(mithep::Jet::ECorr l) const
     { return l < fMaxCorrLevel && std::find(fLevels.begin(), fLevels.end(), l) != fLevels.end(); }
+
+    void Correct(mithep::Jet&, Double_t rho = 0.) const;
 
     static mithep::Jet::ECorr TranslateLevel(char const* levelName);
 
@@ -50,7 +53,8 @@ namespace mithep {
     std::vector<mithep::Jet::ECorr> fLevels{};
     mithep::Jet::ECorr fMaxCorrLevel = mithep::Jet::nECorrs;
     FactorizedJetCorrector* fCorrector = 0;
-    Int_t fSigma = 0;
+    JetCorrectionUncertainty* fUncertainty = 0;
+    Double_t fSigma = 0.;
 
     ClassDef(JetCorrector, 0)
   };

--- a/Utils/src/JetCorrector.cc
+++ b/Utils/src/JetCorrector.cc
@@ -13,6 +13,7 @@ ClassImp(mithep::JetCorrector)
 mithep::JetCorrector::~JetCorrector()
 {
   delete fCorrector;
+  delete fUncertainty;
 }
 
 void


### PR DESCRIPTION
Adding an option to JetCorrectinMod and MetCorrectionMod to scale the JEC additionally by (1 + n \* sigma), where sigma is the uncertainty provided by JetMET and n is a configurable parameter.
This last factor will be stored in the output jet as the "Custom" level JEC.
Currently uncertainty can only be added to L1+L2+L3(+L2L3Residual) correction.
