### PR TITLE
Metcorr etalimit

### DIFF
--- a/Mods/interface/MetCorrectionMod.h
+++ b/Mods/interface/MetCorrectionMod.h
@@ -21,6 +21,8 @@
 
 #include "TFormula.h"
 
+#include <limits>
+
 namespace mithep {
 
   class BaseCollection;
@@ -56,17 +58,22 @@ namespace mithep {
     void ApplyType0(bool b)                    { fApplyType0 = b; }
     void ApplyType1(bool b)                    { fApplyType1 = b; }
     void ApplyShift(bool b)                    { fApplyShift = b; }
+    // type 0 parameters
     void SetExprType0(const char *expr)        { MakeFormula(0, expr); }
     void SetPFCandidatesName(const char *name) { fPFCandidatesName = name; }
     void SetExprShiftPx(const char *expr)  { MakeFormula(1, expr); }
     void SetExprShiftPy(const char *expr)  { MakeFormula(2, expr); }
+    // type 1 parameters
     void AddJetCorrectionFromFile(char const* file);
     void SetJESUncertaintySigma(Double_t s)    { fJESUncertaintySigma = s; }
     void SetJetCorrector(JetCorrector*);
     void SetRhoAlgo(UInt_t a)                  { fRhoAlgo = a; }
     void SetMaxEMFraction(Double_t m)          { fMaxEMFraction = m; }
     void SetSkipMuons(Bool_t s)                { fSkipMuons = s; }
+    void SetMaxJetEta(Double_t m)              { fMaxJetEta = m; }
+    // shift parameters
     void IsData(bool b)                        { fIsData = b; }
+
     void SetPrint(bool b)                      { fPrint = b; }
 
   protected:
@@ -96,10 +103,10 @@ namespace mithep {
     JetCorrector* fJetCorrector = 0; //For type 1 correction. Can be created internally or set externally
     UInt_t        fRhoAlgo = PileupEnergyDensity::kFixedGridFastjetAll;
     Double_t      fJESUncertaintySigma = 0.;
-
     Double_t      fMaxEMFraction = -1.; //maximum charged + neutral EM energy fraction
                                         //for jet to be in Type1 corr (< 0 -> does not skip jets)
     Bool_t        fSkipMuons = kFALSE; //remove muon P4 from jet P4 in Type 1 corr
+    Double_t      fMaxJetEta = std::numeric_limits<double>::max();
                   
     Bool_t        fIsData = kTRUE; //flag for data/MC distinction
     Bool_t        fPrint = kFALSE; //flag for debug print out

--- a/Mods/src/MetCorrectionMod.cc
+++ b/Mods/src/MetCorrectionMod.cc
@@ -209,6 +209,11 @@ MetCorrectionMod::Process()
       auto& inJet = *inJets->At(iJ);
       auto&& inJetRawMom(inJet.RawMom());
 
+      double absEta = inJetRawMom.AbsEta();
+
+      if (absEta > fMaxJetEta)
+        continue;
+
       if (fMaxEMFraction > 0.) {
         if (inJet.ObjType() == kPFJet) {
           auto& inPFJet = static_cast<PFJet const&>(inJet);
@@ -237,14 +242,14 @@ MetCorrectionMod::Process()
 
       double fullCorr;
       double offsetCorr;
-      if (inJet.AbsEta() < 9.9) {
+      if (absEta < 9.9) {
         std::vector<float>&& corr(fJetCorrector->CorrectionFactors(inJet, rho));
         fullCorr = corr.back() * fJetCorrector->UncertaintyFactor(inJet);
         offsetCorr = corr.front();
       }
       else {
         auto modJet(inJet);
-        modJet.SetRawPtEtaPhiM(inJetRawMom.Pt(), inJet.Eta() / inJet.AbsEta() * 9.9, inJetRawMom.Phi(), inJetRawMom.M());
+        modJet.SetRawPtEtaPhiM(inJetRawMom.Pt(), inJet.Eta() / absEta * 9.9, inJetRawMom.Phi(), inJetRawMom.M());
         std::vector<float>&& corr(fJetCorrector->CorrectionFactors(modJet, rho));
         fullCorr = corr.back() * fJetCorrector->UncertaintyFactor(modJet);
         offsetCorr = corr.front();

--- a/Mods/src/MetCorrectionMod.cc
+++ b/Mods/src/MetCorrectionMod.cc
@@ -209,7 +209,7 @@ MetCorrectionMod::Process()
       auto& inJet = *inJets->At(iJ);
       auto&& inJetRawMom(inJet.RawMom());
 
-      double absEta = inJetRawMom.AbsEta();
+      double absEta = inJet.AbsEta();
 
       if (absEta > fMaxJetEta)
         continue;


### PR DESCRIPTION
Added an option to set an eta limit to the jets used in type 1 MET correction.
