### PR TITLE
bugfix PhotonId default isolation

### DIFF
--- a/Mods/python/PhotonIdMod.py
+++ b/Mods/python/PhotonIdMod.py
@@ -3,7 +3,7 @@ from MitAna.TreeMod.bambu import mithep
 photonIdMod = mithep.PhotonIdMod(
     OutputName = 'LoosePhotons',
     IdType = mithep.PhotonTools.kPhys14Loose,
-    IsoType = mithep.PhotonTools.kPhys14Loose,
+    IsoType = mithep.PhotonTools.kPhys14LooseIso,
     PtMin = 15.,
     EtaMax = 2.5
 )


### PR DESCRIPTION
Default python configuration for PhotonIdMod had a wrong flag for isolation.
