### PR TITLE
Reset() was used for Arrays where they should have been Delete()

### DIFF
--- a/Mods/src/JetCorrectionMod.cc
+++ b/Mods/src/JetCorrectionMod.cc
@@ -90,7 +90,7 @@ JetCorrectionMod::Process()
     return;
   }
 
-  fCorrectedJets.Reset();
+  fCorrectedJets.Delete();
 
   // loop over jets
   for (unsigned iJ = 0; iJ != inJets->GetEntries(); ++iJ) {

--- a/Mods/src/MetCorrectionMod.cc
+++ b/Mods/src/MetCorrectionMod.cc
@@ -113,7 +113,7 @@ MetCorrectionMod::Process()
   }
 
   // prepare the storage array for the corrected MET
-  fOutput->Reset();
+  fOutput->Delete();
 
   TVector2 metCorrection[3] = {};
   double sumEtCorrection[3] = {};


### PR DESCRIPTION
There was a memory leak in the corrected jet and met collections because the allocated memory for references to constituents is not freed.
