### PR TITLE
disabling HBHENoiseFilter for the time being

### DIFF
--- a/SelMods/python/BadEventsFilterMod.py
+++ b/SelMods/python/BadEventsFilterMod.py
@@ -3,5 +3,5 @@ from MitAna.TreeMod.bambu import mithep
 badEventsFilterMod = mithep.BadEventsFilterMod('BadEventsFilterMod',
     EEBadScFilter = True,
     CSCTightHaloFilter = True,
-    HBHENoiseFilter = True
+    HBHENoiseFilter = False
 )


### PR DESCRIPTION
Huge inefficiency observed in WJets HT 100-200 MC. HBHENoiseFilter is not supposed to affect MC strongly - turning off in the default setting until the problem is understood.
