### PR TITLE
setting HBHENoiseFilter on for data

### DIFF
--- a/SelMods/python/BadEventsFilterMod.py
+++ b/SelMods/python/BadEventsFilterMod.py
@@ -1,7 +1,7 @@
-from MitAna.TreeMod.bambu import mithep
+from MitAna.TreeMod.bambu import mithep, analysis
 
 badEventsFilterMod = mithep.BadEventsFilterMod('BadEventsFilterMod',
     EEBadScFilter = True,
     CSCTightHaloFilter = True,
-    HBHENoiseFilter = False
+    HBHENoiseFilter = analysis.isRealData
 )


### PR DESCRIPTION
Issue seen in HBHE noise filter last week was understood; was using 50 ns configuration for all, and I looked at a 25 ns MC. MitProd will be updated to use separate configurations for 25 and 50. Meanwhile, since current setup is correct for data and the filter is relevant only for data anyway, we are turning on the filter by default.
