### PR TITLE
Puppi jets and improvements to XlFatJet filler

### DIFF
--- a/Mods/BuildFile.xml
+++ b/Mods/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="MitPhysics/SDAlgorithm"/>
 <use   name="fastjet"/>
 <use   name="fastjet-contrib"/>
-<use   name="RecoJets/JetAlgorithms"/>
+<use   name="qjets"/>
 <use   name="root"/>
 <use   name="roottmva"/>
 <use   root=""/>

--- a/Mods/BuildFile.xml
+++ b/Mods/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="MitPhysics/SDAlgorithm"/>
 <use   name="fastjet"/>
 <use   name="fastjet-contrib"/>
-<use   name="qjets"/>
+<use   name="RecoJets/JetAlgorithms"/>
 <use   name="root"/>
 <use   name="roottmva"/>
 <use   root=""/>

--- a/Mods/dict/MitPhysicsModsLinkDef.h
+++ b/Mods/dict/MitPhysicsModsLinkDef.h
@@ -23,6 +23,7 @@
 #include "MitPhysics/Mods/interface/MuonIDModRun1.h"
 #include "MitPhysics/Mods/interface/PDFProducerMod.h"
 #include "MitPhysics/Mods/interface/PartonFlavorHistoryMod.h"
+#include "MitPhysics/Mods/interface/PuppiJetMod.h"
 #include "MitPhysics/Mods/interface/PhotonCleaningMod.h"
 #include "MitPhysics/Mods/interface/PhotonIdMod.h"
 #include "MitPhysics/Mods/interface/PhotonIDModRun1.h"
@@ -87,6 +88,8 @@
 #pragma link C++ class mithep::PhotonTreeWriterDiphotonEvent+;
 #pragma link C++ class mithep::PhotonTreeWriterVtx+;
 #pragma link C++ class mithep::PuppiMod+;
+#pragma link C++ class mithep::PuppiPFJetMod+;
+#pragma link C++ class mithep::PuppiFatJetMod+;
 #pragma link C++ class mithep::PFTauCleaningMod+;
 #pragma link C++ class mithep::TauIDMod+;
 #pragma link C++ class mithep::TauCleaningMod+;

--- a/Mods/interface/FatJetExtenderMod.h
+++ b/Mods/interface/FatJetExtenderMod.h
@@ -43,6 +43,7 @@
 #include "MitPhysics/SDAlgorithm/interface/ISRModel.h"
 #include "MitPhysics/SDAlgorithm/interface/Deconstruct.h"
 #include "MitPhysics/SDAlgorithm/interface/ParseUtils.h"
+#include "MitAna/PhysicsUtils/interface/CMSTopTagger.h"
 #include "TStopwatch.h"
 
 namespace mithep
@@ -154,6 +155,7 @@ namespace mithep
       fastjet::JetDefinition *fCAJetDef;   //fastjet clustering definition
       fastjet::GhostedAreaSpec *fActiveArea;
       fastjet::AreaDefinition *fAreaDefinition;
+      fastjet::CMSTopTagger* fCMSTopTagger;
 
       unsigned short fSubJetFlags = 1;    // flags turning on subjet types
 

--- a/Mods/interface/FatJetExtenderMod.h
+++ b/Mods/interface/FatJetExtenderMod.h
@@ -89,6 +89,7 @@ namespace mithep
       void SetDoQjets(Bool_t b)            { fDoQjets = b; }
       void SetNMaxMicrojets(unsigned int n)         { fNMaxMicrojets = n; }
       void SetDebugFlag(int i)   { fDebugFlag = i; }
+      void SetSDInputCard(const char *s)   { fInputCard = s;  }          
     protected:
       void Process();
       void SlaveBegin();
@@ -170,7 +171,8 @@ namespace mithep
       Deconstruction::TopGluonModel *fSignal;
       Deconstruction::BackgroundModel *fBackground;
       Deconstruction::ISRModel *fISR; 
-      
+      TString fInputCard;
+
       UInt_t fProcessNJets;
 
       Bool_t fDoShowerDeconstruction;

--- a/Mods/interface/FatJetExtenderMod.h
+++ b/Mods/interface/FatJetExtenderMod.h
@@ -3,7 +3,7 @@
 //
 // FatJetExtender
 //
-// This module processes a collection of input fatjets, compute the substrucure
+// This module processes a collection of input FatJets, compute the substrucure
 // and fill a output collections of fXlFatJets
 //
 // Authors: L.DiMatteo, S.Narayanan
@@ -43,6 +43,7 @@
 #include "MitPhysics/SDAlgorithm/interface/ISRModel.h"
 #include "MitPhysics/SDAlgorithm/interface/Deconstruct.h"
 #include "MitPhysics/SDAlgorithm/interface/ParseUtils.h"
+#include "TStopwatch.h"
 
 namespace mithep
 {
@@ -81,7 +82,10 @@ namespace mithep
       void SetPFCandsName(const char *n)   { fPFCandidatesName = n; }
       void SetPileUpDenName(const char *n) { fPileUpDenName = n;    }
       void SetVertexesName(const char *n)  { fVertexesName = n;     }
-
+      void SetDoShowerDeconstruction(Bool_t b) { fDoShowerDeconstruction = b; }
+      void SetBeVerbose(Bool_t b)          { fBeVerbose = b;  }
+      void SetDoECF(Bool_t b)              { fDoECF = b; }
+      void SetNMaxMicrojets(unsigned int n)         { fNMaxMicrojets = n; }
     protected:
       void Process();
       void SlaveBegin();
@@ -166,8 +170,13 @@ namespace mithep
 
       Bool_t fDoShowerDeconstruction;
 
-      // QG tagger
       QGTagger *fQGTagger;                 //QGTagger calculator
+      
+      Bool_t fBeVerbose;
+      Bool_t fDoECF;                       // this is now a user-set option, as it's quite slow 
+      unsigned int fNMaxMicrojets;
+      
+      TStopwatch *fStopwatch;
 
       // Counters : used to initialize seed for QJets volatility
       Long64_t fCounter;

--- a/Mods/interface/FatJetExtenderMod.h
+++ b/Mods/interface/FatJetExtenderMod.h
@@ -86,6 +86,7 @@ namespace mithep
       void SetDoShowerDeconstruction(Bool_t b) { fDoShowerDeconstruction = b; }
       void SetBeVerbose(Bool_t b)          { fBeVerbose = b;  }
       void SetDoECF(Bool_t b)              { fDoECF = b; }
+      void SetDoQjets(Bool_t b)            { fDoQjets = b; }
       void SetNMaxMicrojets(unsigned int n)         { fNMaxMicrojets = n; }
       void SetDebugFlag(int i)   { fDebugFlag = i; }
     protected:
@@ -178,6 +179,7 @@ namespace mithep
       
       Bool_t fBeVerbose;
       Bool_t fDoECF;                       // this is now a user-set option, as it's quite slow 
+      Bool_t fDoQjets;
       unsigned int fNMaxMicrojets;
       
       TStopwatch *fStopwatch;

--- a/Mods/interface/FatJetExtenderMod.h
+++ b/Mods/interface/FatJetExtenderMod.h
@@ -87,6 +87,7 @@ namespace mithep
       void SetBeVerbose(Bool_t b)          { fBeVerbose = b;  }
       void SetDoECF(Bool_t b)              { fDoECF = b; }
       void SetNMaxMicrojets(unsigned int n)         { fNMaxMicrojets = n; }
+      void SetDebugFlag(int i)   { fDebugFlag = i; }
     protected:
       void Process();
       void SlaveBegin();
@@ -113,6 +114,7 @@ namespace mithep
       double FindMean(std::vector<float>);
 
       Vect4M GetCorrectedMomentum(fastjet::PseudoJet fj_tmp, double thisJEC);
+
 
     private:
       Bool_t fIsData;                      //is this data or MC?
@@ -182,6 +184,8 @@ namespace mithep
 
       // Counters : used to initialize seed for QJets volatility
       Long64_t fCounter;
+
+      int fDebugFlag = -1;
 
       ClassDef(FatJetExtenderMod, 0)         //XlJets, Fat and Sub, filler
   };

--- a/Mods/interface/PuppiJetMod.h
+++ b/Mods/interface/PuppiJetMod.h
@@ -1,0 +1,132 @@
+//--------------------------------------------------------------------------------------------------
+// $Id: PuppiJetMod.h,v 1.9 2011/03/01 17:27:22 mzanetti Exp $
+//
+// PuppiJetMod
+//
+// This mod processes an input collection of particles (i.e. from PuppiMod) and returns
+// a collection of jets (of type JETTYPE)
+//
+// Authors:S.Narayanan
+//--------------------------------------------------------------------------------------------------
+
+#ifndef MITPHYSICS_MODS_PUPPIJETMOD_H
+#define MITPHYSICS_MODS_PUPPIJETMOD_H
+
+#include <TVector2.h>
+
+#include "fastjet/PseudoJet.hh"
+#include "fastjet/JetDefinition.hh"
+#include "fastjet/GhostedAreaSpec.hh"
+#include "fastjet/AreaDefinition.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+
+#include "MitAna/TreeMod/interface/BaseMod.h"
+#include "MitAna/DataTree/interface/JetCol.h"
+#include "MitAna/DataTree/interface/FatJetCol.h"
+#include "MitAna/DataTree/interface/PFCandidateCol.h"
+#include "MitAna/DataTree/interface/PFJetCol.h"
+
+#include "MitCommon/DataFormats/interface/Vect4M.h"
+#include "MitCommon/DataFormats/interface/Vect3.h"
+#include "MitCommon/DataFormats/interface/Types.h"
+#include "MitCommon/MathTools/interface/MathUtils.h"
+#include "MitAna/DataTree/interface/Names.h"
+
+
+
+#include "TStopwatch.h"
+
+namespace mithep
+{
+  template<typename JETTYPE>
+   class PuppiJetMod : public BaseMod
+  {
+    public:
+      enum JetAlgorithm {
+        kAntiKT,
+        kCambridgeAachen,
+        kKT, // why?
+        nJetAlgorithm
+      };
+
+      PuppiJetMod(const char *name = "PuppiJetMod",
+                   const char *title = "Puppi jet module");
+      ~PuppiJetMod();
+
+      void IsData(Bool_t b)                { fIsData = b;           }
+      void PublishOutput(Bool_t b)         { fPublishOutput = b;    }
+      
+      void SetProcessNJets(UInt_t n)       { fProcessNJets = n;     }
+
+      void SetInputName(const char *n)      { fPFCandidatesName = n;         }
+
+      void SetOutputName(const char *n)   { fJetsName = n;    }
+      void SetR0(double d)                { fR0 = d;  }
+      void SetBeVerbose(Bool_t b)          { fBeVerbose = b;  }
+      void SetDebugFlag(int i)   { fDebugFlag = i; }
+
+      void SetDoMatching(Bool_t b)              { fDoMatching = b;  }
+      void SetMatchingJetsName(const char *n)   { fMatchingJetsName = n;  }
+
+      void SetJetAlgorithm(JetAlgorithm j)      { fJetAlgorithm = j; }
+
+      const char *GetOutputName()               { return fJetsName; }
+
+    protected:
+      void Process();
+      void SlaveBegin();
+      void SlaveTerminate();
+
+      // Jet collection helpers
+      std::vector <fastjet::PseudoJet>
+            Sorted_by_pt_min_pt(std::vector <fastjet::PseudoJet> &jets,
+                                float jetPtMin);
+
+      Vect4M GetCorrectedMomentum(fastjet::PseudoJet fj_tmp, double thisJEC);
+
+      void RunMatching(PFJet*);
+      void RunMatching(FatJet*);
+
+
+    private:
+      Bool_t fIsData;                      //is this data or MC?
+      Bool_t fPublishOutput;               //=true if output collection are published
+
+      TString fPFCandidatesName;           //(i) name of PF candidates coll
+      const PFCandidateCol *fPFCandidates; //particle flow candidates coll handle
+
+      TString fJetsName;              //name of output jets collection
+      Array<JETTYPE> *fJets;             //array of jets
+
+      // Objects from fastjet we want to use
+      double fR0;                    //fastjet clustering radius
+      fastjet::JetDefinition *fJetDef;   //fastjet clustering definition
+      fastjet::GhostedAreaSpec *fActiveArea;
+      fastjet::AreaDefinition *fAreaDefinition;
+
+      Bool_t fDoMatching;
+      TString fMatchingJetsName;
+      const Collection<Jet> *fMatchingJets;
+
+      UInt_t fProcessNJets;
+
+      Bool_t fBeVerbose;
+
+      JetAlgorithm fJetAlgorithm;
+      
+      TStopwatch *fStopwatch;
+
+      int fDebugFlag = -1;
+
+      ClassDef(PuppiJetMod, 0)         //Puppi jets filler
+  };
+
+typedef PuppiJetMod<FatJet> PuppiFatJetMod;
+typedef PuppiJetMod<PFJet>  PuppiPFJetMod;
+
+#include "MitPhysics/Mods/src/PuppiJetMod.icc"
+
+}
+
+
+#endif

--- a/Mods/python/PuppiFatJetMod.py
+++ b/Mods/python/PuppiFatJetMod.py
@@ -1,0 +1,9 @@
+from MitAna.TreeMod.bambu import mithep
+import os
+
+puppiFatJetMod = mithep.PuppiFatJetMod(
+    InputName = "PuppiParticles",
+    OutputName = 'PuppiFatJets',
+    ProcessNJets = 4,
+    R0 = 0.8
+)

--- a/Mods/python/PuppiMod.py
+++ b/Mods/python/PuppiMod.py
@@ -2,7 +2,7 @@ import os
 from MitAna.TreeMod.bambu import mithep
 
 puppiMod = mithep.PuppiMod(
-    EtaConfigName = os.getenv("CMSSW_BASE")+'/src/MitPhysics/data/PuppiEta_150701.cfg',
+    EtaConfigName = os.getenv("MIT_DATA")+'/PuppiEta_150701.cfg',
     OutputName = 'PuppiParticles',
     RMin = 0.02,
     R0 = 0.3,

--- a/Mods/python/PuppiPFJetMod.py
+++ b/Mods/python/PuppiPFJetMod.py
@@ -1,0 +1,9 @@
+from MitAna.TreeMod.bambu import mithep
+import os
+
+puppiPFJetMod = mithep.PuppiPFJetMod(
+    InputName = "PuppiParticles",
+    OutputName = 'PuppiPFJets',
+    ProcessNJets = 10,
+    R0 = 0.4
+)

--- a/Mods/src/FatJetExtenderMod.cc
+++ b/Mods/src/FatJetExtenderMod.cc
@@ -9,8 +9,8 @@
 #include "MitCommon/MathTools/interface/MathUtils.h"
 #include "MitAna/PhysicsUtils/interface/CMSTopTagger.h"
 #include "MitAna/PhysicsUtils/interface/HEPTopTagger.h"
-#include "QjetsPlugin.h"
-#include "Qjets.h"
+#include "RecoJets/JetAlgorithms/interface/QjetsPlugin.h"
+#include "RecoJets/JetAlgorithms/interface/Qjets.h"
 
 #include "fastjet/contrib/Njettiness.hh"
 #include "fastjet/contrib/EnergyCorrelator.hh"

--- a/Mods/src/FatJetExtenderMod.cc
+++ b/Mods/src/FatJetExtenderMod.cc
@@ -324,14 +324,19 @@ void FatJetExtenderMod::FillXlFatJet(const FatJet *fatJet)
     // okay, we really do want to save this collection
     std::vector<fastjet::PseudoJet> fjSubjets;
     if (iSJType <= XlSubJet::kTrimmed) {
+      if (!fjClusteredJets[iSJType].has_constituents()) 
+        // if subjet finding failed, skip this step
+        continue;
       // these have a common interface
       int nSubJets = std::min<unsigned int>(fjClusteredJets[iSJType].constituents().size(),3);
-      fjSubjets = fjClusteredJets[iSJType].associated_cluster_sequence()->exclusive_subjets(fjClusteredJets[iSJType],nSubJets);
-      std::vector<fastjet::PseudoJet> fjSubJetsSorted = Sorted_by_pt_min_pt(fjSubjets,0.01);
-      if (!computedPullAngle) {
-        xlFatJet->SetPullAngle(GetPullAngle(fjSubJetsSorted,0.01));
+      if (nSubJets>0) {
+        fjSubjets = fjClusteredJets[iSJType].associated_cluster_sequence()->exclusive_subjets(fjClusteredJets[iSJType],nSubJets);
+        std::vector<fastjet::PseudoJet> fjSubJetsSorted = Sorted_by_pt_min_pt(fjSubjets,0.01);
+        if (!computedPullAngle) {
+          xlFatJet->SetPullAngle(GetPullAngle(fjSubJetsSorted,0.01));
+        }
+        FillXlSubJets(fjSubJetsSorted,xlFatJet,(ESubJetType)iSJType);
       }
-      FillXlSubJets(fjSubJetsSorted,xlFatJet,(ESubJetType)iSJType);
     } else if (iSJType == XlSubJet::kCMSTT) {
       fjSubjets = cmsTopJet.pieces();
       FillXlSubJets(fjSubjets,xlFatJet,XlSubJet::kCMSTT);
@@ -391,7 +396,7 @@ void FatJetExtenderMod::FillXlFatJet(const FatJet *fatJet)
   xlFatJet->SetC2b2(C2b2);
 
   xlFatJet->SetQJetVol(QJetVol);
-
+  
   // Store the groomed masses, apply JEC
   xlFatJet->SetMassSDb0(MassSDb0*thisJEC);
   xlFatJet->SetMassSDb1(MassSDb1*thisJEC);

--- a/Mods/src/FatJetExtenderMod.cc
+++ b/Mods/src/FatJetExtenderMod.cc
@@ -25,7 +25,7 @@ ClassImp(mithep::FatJetExtenderMod)
 //--------------------------------------------------------------------------------------------------
 FatJetExtenderMod::FatJetExtenderMod(const char *name, const char *title) :
   BaseMod (name,title),
-  fIsData (kTRUE),
+  fIsData (kFALSE),
   fQGTaggingActive (kTRUE),
   fQGTaggerCHS (kFALSE),
   fPublishOutput (kTRUE),

--- a/Mods/src/FatJetExtenderMod.cc
+++ b/Mods/src/FatJetExtenderMod.cc
@@ -198,8 +198,8 @@ void FatJetExtenderMod::SlaveBegin()
   fQGTagger = new QGTagger(fQGTaggerCHS);
 
   // set up shower deconstruction stuff
-  TString inputCard = Utils::GetEnv("CMSSW_BASE");
-  inputCard += TString::Format("/src/MitPhysics/SDAlgorithm/config/input_card_%i.dat",int(fConeSize*10));
+  TString inputCard = Utils::GetEnv("MIT_DATA");
+  inputCard += TString::Format("/SDAlgorithm/input_card_%i.dat",int(fConeSize*10));
   fParam = new AnalysisParameters(inputCard.Data());
   fSignal = new Deconstruction::TopGluonModel(*fParam);
   fBackground = new Deconstruction::BackgroundModel(*fParam);

--- a/Mods/src/FatJetExtenderMod.cc
+++ b/Mods/src/FatJetExtenderMod.cc
@@ -50,10 +50,12 @@ FatJetExtenderMod::FatJetExtenderMod(const char *name, const char *title) :
   fTrimPtFrac (0.05),
   fConeSize (0.8),
   fDeconstruct(0),
+  fInputCard(""),
   fProcessNJets (4),
   fDoShowerDeconstruction(kFALSE),
   fBeVerbose(kFALSE),
   fDoECF(kFALSE),
+  fDoQjets(kFALSE),
   fNMaxMicrojets(5)
 {
   // Constructor.
@@ -62,49 +64,6 @@ FatJetExtenderMod::FatJetExtenderMod(const char *name, const char *title) :
 
 FatJetExtenderMod::~FatJetExtenderMod()
 {
-  // Destructor
-  if (fXlSubJets){
-    for(int i=0; i<XlSubJet::nSubJetTypes; ++i) {
-      if (fSubJetFlags & (1<<i))
-        delete fXlSubJets[i];
-    }
-  }
-
-  if (fXlFatJets)
-    delete fXlFatJets;
-
-  if (fPruner)
-    delete fPruner;
-  if (fFilterer)
-    delete fFilterer;
-  if (fTrimmer)
-    delete fTrimmer ;
-  if (fCMSTopTagger)
-    delete fCMSTopTagger;
-  if (fCAJetDef)
-    delete fCAJetDef;
-
-  if (fActiveArea)
-    delete fActiveArea;
-  if (fAreaDefinition)
-    delete fAreaDefinition;
-
-  if (fQGTagger)
-    delete fQGTagger;
-
-  if (fDeconstruct)
-    delete fDeconstruct;
-  if (fParam)
-    delete fParam;
-  if (fSignal)
-    delete fSignal;
-  if (fBackground)
-    delete fBackground;
-  if (fISR)
-    delete fISR;
-
-  if (fStopwatch)
-    delete fStopwatch;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -212,9 +171,12 @@ void FatJetExtenderMod::SlaveBegin()
   fQGTagger = new QGTagger(fQGTaggerCHS);
 
   // set up shower deconstruction stuff
-  TString inputCard = Utils::GetEnv("MIT_DATA");
-  inputCard += TString::Format("/SDAlgorithm/input_card_%i.dat",int(fConeSize*10));
-  fParam = new AnalysisParameters(inputCard.Data());
+  if (fInputCard=="") {
+    // default was never changed
+    fInputCard = Utils::GetEnv("MIT_DATA");
+    fInputCard += TString::Format("/SDAlgorithm/input_card_%i.dat",int(fConeSize*10));
+  }
+  fParam = new AnalysisParameters(fInputCard.Data());
   fSignal = new Deconstruction::TopGluonModel(*fParam);
   fBackground = new Deconstruction::BackgroundModel(*fParam);
   fISR = new Deconstruction::ISRModel(*fParam);
@@ -228,6 +190,55 @@ void FatJetExtenderMod::SlaveBegin()
 //--------------------------------------------------------------------------------------------------
 void FatJetExtenderMod::SlaveTerminate()
 {
+  RetractObj(fXlFatJets->GetName());
+  for(int i=0; i<XlSubJet::nSubJetTypes; ++i) {
+    if (fSubJetFlags & (1<<i))
+      RetractObj(fXlSubJets[i]->GetName());
+  }
+
+  // Destructor
+  if (fXlSubJets){
+    for(int i=0; i<XlSubJet::nSubJetTypes; ++i) {
+      if (fSubJetFlags & (1<<i))
+        delete fXlSubJets[i];
+    }
+  }
+
+  if (fXlFatJets)
+    delete fXlFatJets;
+
+  if (fPruner)
+    delete fPruner;
+  if (fFilterer)
+    delete fFilterer;
+  if (fTrimmer)
+    delete fTrimmer ;
+  if (fCMSTopTagger)
+    delete fCMSTopTagger;
+  if (fCAJetDef)
+    delete fCAJetDef;
+
+  if (fActiveArea)
+    delete fActiveArea;
+  if (fAreaDefinition)
+    delete fAreaDefinition;
+
+  if (fQGTagger)
+    delete fQGTagger;
+
+  if (fDeconstruct)
+    delete fDeconstruct;
+  if (fParam)
+    delete fParam;
+  if (fSignal)
+    delete fSignal;
+  if (fBackground)
+    delete fBackground;
+  if (fISR)
+    delete fISR;
+
+  if (fStopwatch)
+    delete fStopwatch;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Mods/src/FatJetExtenderMod.cc
+++ b/Mods/src/FatJetExtenderMod.cc
@@ -134,7 +134,7 @@ void FatJetExtenderMod::Process()
     if (i >= fProcessNJets)
       break;
 
-    const FatJet *jet = static_cast<const FatJet*>(fFatJets->At(i));
+    const FatJet *jet = dynamic_cast<const FatJet*>(fFatJets->At(i));
     if (! jet) {
       printf(" FatJetExtenderMod::Process() - ERROR - jets provided are not FatJets.");
       break;
@@ -373,7 +373,7 @@ void FatJetExtenderMod::FillXlFatJet(const FatJet *fatJet)
   // fill subjets
   Bool_t computedPullAngle = kFALSE;
   for (unsigned int iSJType = 0; iSJType!=XlSubJet::nSubJetTypes; ++iSJType) {
-    if (fSubJetFlags & ~(1<<iSJType))
+    if (!(fSubJetFlags & (1<<iSJType)))
       continue;
     // okay, we really do want to save this collection
     std::vector<fastjet::PseudoJet> fjSubjets;

--- a/Mods/src/FatJetExtenderMod.cc
+++ b/Mods/src/FatJetExtenderMod.cc
@@ -48,7 +48,7 @@ FatJetExtenderMod::FatJetExtenderMod(const char *name, const char *title) :
   fFilterRad (0.2),
   fTrimRad (0.2),
   fTrimPtFrac (0.05),
-  fConeSize (0.6),
+  fConeSize (0.8),
   fDeconstruct(0),
   fProcessNJets (4),
   fDoShowerDeconstruction(kFALSE),
@@ -82,22 +82,38 @@ FatJetExtenderMod::~FatJetExtenderMod()
   if (fXlFatJets)
     delete fXlFatJets;
 
-  delete fPruner;
-  delete fFilterer;
-  delete fTrimmer ;
-  delete fCMSTopTagger;
-  delete fCAJetDef;
+  if (fPruner)
+    delete fPruner;
+  if (fFilterer)
+    delete fFilterer;
+  if (fTrimmer)
+    delete fTrimmer ;
+  if (fCMSTopTagger)
+    delete fCMSTopTagger;
+  if (fCAJetDef)
+    delete fCAJetDef;
 
-  delete fActiveArea;
-  delete fAreaDefinition;
+  if (fActiveArea)
+    delete fActiveArea;
+  if (fAreaDefinition)
+    delete fAreaDefinition;
 
-  delete fQGTagger;
+  if (fQGTagger)
+    delete fQGTagger;
 
-  delete fDeconstruct;
-  delete fParam;
-  delete fSignal;
-  delete fBackground;
-  delete fISR;
+  if (fDeconstruct)
+    delete fDeconstruct;
+  if (fParam)
+    delete fParam;
+  if (fSignal)
+    delete fSignal;
+  if (fBackground)
+    delete fBackground;
+  if (fISR)
+    delete fISR;
+
+  if (fStopwatch)
+    delete fStopwatch;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -256,6 +272,8 @@ void FatJetExtenderMod::FillXlFatJet(const FatJet *fatJet)
   // Check that the output collection size is non-null, otherwise nothing to be done further
   if (fjOutJets.size() < 1) {
     printf(" FatJetExtenderMod::FillXlFatJet() - WARNING - input FatJet produces null reclustering output!\n");
+    if (fjClustering->inclusive_jets(0.).size()>0)
+      fjClustering->delete_self_when_unused();
     delete fjClustering;
 
     return;
@@ -309,7 +327,7 @@ void FatJetExtenderMod::FillXlFatJet(const FatJet *fatJet)
   			fprintf(stderr,"Finished ECF calculation in %f seconds\n",fStopwatch->RealTime()); fStopwatch->Start();
   		}
   }
-  
+
   // Compute Q-jets volatility
   std::vector<fastjet::PseudoJet> constits;
   GetJetConstituents(fjJet, constits, 0.01);
@@ -434,11 +452,10 @@ void FatJetExtenderMod::FillXlFatJet(const FatJet *fatJet)
     if (fBeVerbose) {
 			fprintf(stderr,"Finished shower deconstruction in %f seconds\n",fStopwatch->RealTime()); fStopwatch->Start();
 		}
-    if (cs_micro->inclusive_jets().size()>0)
+    if (cs_micro->inclusive_jets(0.).size()>0)
       cs_micro->delete_self_when_unused();
-    delete cs_micro; 
+    delete cs_micro;
   }
-
 
   // Store groomed 4-momenta, apply JEC
   fastjet::PseudoJet fj_tmp;
@@ -462,7 +479,7 @@ void FatJetExtenderMod::FillXlFatJet(const FatJet *fatJet)
   fXlFatJets->Trim();
 
   // Memory cleanup
-  if (fjOutJets.size() > 0)
+  if (fjClustering->inclusive_jets().size() > 0)
     fjClustering->delete_self_when_unused();
   delete fjClustering;
     if (fBeVerbose) {

--- a/Mods/src/FatJetExtenderMod.cc
+++ b/Mods/src/FatJetExtenderMod.cc
@@ -9,8 +9,8 @@
 #include "MitCommon/MathTools/interface/MathUtils.h"
 #include "MitAna/PhysicsUtils/interface/CMSTopTagger.h"
 #include "MitAna/PhysicsUtils/interface/HEPTopTagger.h"
-#include "RecoJets/JetAlgorithms/interface/QjetsPlugin.h"
-#include "RecoJets/JetAlgorithms/interface/Qjets.h"
+#include "QjetsPlugin.h"
+#include "Qjets.h"
 
 #include "fastjet/contrib/Njettiness.hh"
 #include "fastjet/contrib/EnergyCorrelator.hh"
@@ -544,7 +544,7 @@ double FatJetExtenderMod::GetQjetVolatility(std::vector <fastjet::PseudoJet> &co
 {
   std::vector<float> qjetmasses;
 
-  double zcut(0.1), dcut_fctr(0.5), exp_min(0.), exp_max(0.), rigidity(0.1), truncationFactor(0.01);
+  double zcut(0.1), dcut_fctr(0.5), exp_min(0.), exp_max(0.), rigidity(0.1), truncationFactor(0.0);
 
   QjetsPlugin qjet_plugin(zcut, dcut_fctr, exp_min, exp_max, rigidity, truncationFactor);
   fastjet::JetDefinition qjet_def(&qjet_plugin);
@@ -555,7 +555,11 @@ double FatJetExtenderMod::GetQjetVolatility(std::vector <fastjet::PseudoJet> &co
     fastjet::ClusterSequence *qjet_seq =
       new fastjet::ClusterSequence(constits, qjet_def);
 
-    vector<fastjet::PseudoJet> inclusive_jets2 = sorted_by_pt(qjet_seq->inclusive_jets(5.0));
+    if (!qjet_plugin.succeeded())
+      return -(seed+ii);  // this will be the error value for when too many jets are left unmerged...needs more investigation, seed is saved so can reproduce
+                          // haha
+
+    vector<fastjet::PseudoJet> inclusive_jets2 = sorted_by_pt(qjet_seq->inclusive_jets(10.0));
     // skip failed recombinations (with no output jets)
     if (inclusive_jets2.size() == 0) {
       nFailed++;

--- a/Mods/src/PuppiJetMod.cc
+++ b/Mods/src/PuppiJetMod.cc
@@ -1,0 +1,5 @@
+#include "MitPhysics/Mods/interface/PuppiJetMod.h"
+
+using namespace mithep;
+
+templateClassImp(PuppiJetMod)  // not sure why explicit ClassImp doesn't work here...

--- a/Mods/src/PuppiJetMod.icc
+++ b/Mods/src/PuppiJetMod.icc
@@ -1,0 +1,252 @@
+
+//--------------------------------------------------------------------------------------------------
+template<typename JETTYPE> PuppiJetMod<JETTYPE>::PuppiJetMod(const char *name, const char *title) :
+  BaseMod (name,title),
+  fIsData (kFALSE),
+  fPublishOutput (kTRUE),
+  fPFCandidatesName ("PuppiParticles"),
+  fPFCandidates (0),
+  fJetsName ("PuppiJets"),
+  fR0(0.4),
+  fDoMatching(kFALSE),
+  fMatchingJetsName(""),
+  fMatchingJets(0),
+  fProcessNJets (4),
+  fJetAlgorithm(kAntiKT)
+{
+  // Constructor.
+
+}
+
+template<typename JETTYPE> PuppiJetMod<JETTYPE>::~PuppiJetMod()
+{
+}
+
+//--------------------------------------------------------------------------------------------------
+template<typename JETTYPE> void PuppiJetMod<JETTYPE>::Process()
+{
+  if (fBeVerbose) fStopwatch->Start(kTRUE);
+
+  // make sure the out collections are empty before starting
+  fJets->Delete();
+  
+  fPFCandidates = GetObject<PFCandidateCol>(fPFCandidatesName);
+  if (fDoMatching)
+    fMatchingJets = GetObject<Collection<Jet>>(fMatchingJetsName);
+  
+  int nPFCandidates = fPFCandidates->GetEntries();
+  std::vector<fastjet::PseudoJet> inPseudoJets;
+
+  // Loop over PFCandidates and unmark them : necessary for skimming
+  // Convert PFCandidates into fastjet::PseudoJets
+  for (int iC=0; iC!=nPFCandidates; ++iC) {
+    const PFCandidate *pfCand = fPFCandidates->At((unsigned int)iC);
+    pfCand->UnmarkMe();
+    fastjet::PseudoJet newPseudoJet(pfCand->Px(),pfCand->Py(),pfCand->Pz(),pfCand->E());
+    newPseudoJet.set_user_index(iC);
+    inPseudoJets.push_back(newPseudoJet);
+  }
+  // cluster puppi jets
+  fastjet::ClusterSequenceArea fjClustering (inPseudoJets,*fJetDef,*fAreaDefinition);
+  std::vector<fastjet::PseudoJet> baseJets = sorted_by_pt(fjClustering.inclusive_jets(0.));
+
+  unsigned int nClusteredJets = baseJets.size();
+  for (unsigned int iJ=0; iJ!=nClusteredJets; ++iJ) {
+    // convert from pseudojets to Bambu jets
+    if (iJ>fProcessNJets)
+      break;
+    fastjet::PseudoJet baseJet = baseJets[iJ];
+    JETTYPE *newJet = fJets->AddNew();
+    newJet->SetRawPtEtaPhiM(baseJet.pt(),baseJet.eta(),baseJet.phi(),baseJet.m());
+    std::vector<fastjet::PseudoJet> baseConstituents = baseJet.constituents();
+
+    // add PFCandidates to the jet and keep track of energy fractions
+    const PFCandidate *pfCand = 0;
+    float chargedEMEnergy=0;
+    float chargedHadEnergy=0;
+    float neutralEMEnergy=0;
+    float neutralHadEnergy=0;
+    float muonEnergy=0;
+    int chargedMult=0;
+    int neutralMult=0;
+    int muonMult=0;
+    for (fastjet::PseudoJet &constituent : baseConstituents) {
+      if (constituent.user_index()<0) 
+        continue; // ghost particle
+      pfCand = fPFCandidates->At((unsigned int)constituent.user_index());
+      newJet->AddPFCand(pfCand);
+      switch (pfCand->PFType()) {
+        case PFCandidate::eHadron:
+          chargedHadEnergy+=pfCand->E();
+          ++chargedMult;
+          break;
+        case PFCandidate::eElectron:
+          chargedEMEnergy+=pfCand->E();
+          ++chargedMult;
+          break;
+        case PFCandidate::eMuon:
+          muonEnergy+=pfCand->E();
+          ++muonMult;
+          break;
+        case PFCandidate::eGamma:
+        case PFCandidate::eEGammaHF:
+          neutralEMEnergy+=pfCand->E();
+          ++neutralMult;
+          break;
+        case PFCandidate::eNeutralHadron:
+        case PFCandidate::eHadronHF:
+          neutralHadEnergy+=pfCand->E();
+          ++neutralMult;
+          break;
+        default:
+          break;
+      }
+    }
+    newJet->SetChargedEmEnergy(chargedEMEnergy);
+    newJet->SetChargedHadronEnergy(chargedHadEnergy);
+    newJet->SetNeutralEmEnergy(neutralEMEnergy);
+    newJet->SetNeutralHadronEnergy(neutralHadEnergy);
+    newJet->SetChargedMuEnergy(muonEnergy);
+    newJet->SetChargedMultiplicity(chargedMult);
+    newJet->SetNeutralMultiplicity(neutralMult);
+    newJet->SetMuonMultiplicity(muonMult);
+
+    if (fDoMatching) {
+      assert(fMatchingJets!=NULL);
+      RunMatching(newJet);
+    }
+  }
+
+  fJets->Trim();
+
+  if (fBeVerbose) fStopwatch->Stop();
+  return;
+}
+
+
+template <typename JETTYPE> void PuppiJetMod<JETTYPE>::RunMatching(PFJet *newJet) {
+  // dR matches a new jet with an existing collection
+  const PFJet *matchedJet = 0;
+  float bestDR2 = 999;
+  for (unsigned int iJ=0; iJ!=fMatchingJets->GetEntries(); ++iJ) {
+    // do dR Matching
+    const PFJet *tmpJet = dynamic_cast<const PFJet*>(fMatchingJets->At(iJ));
+    float dR2 = MathUtils::DeltaR2<const PFJet, PFJet>(tmpJet,newJet);
+    if (dR2<bestDR2) {
+      matchedJet = tmpJet;
+      bestDR2 = dR2;
+    }
+  }
+  if (matchedJet==NULL) {
+    Info("Process","Warning, could not match Puppi jet to a PF jet");
+    return;
+  }
+
+  // copy btags
+  for (unsigned int iBtag=0; iBtag!=(unsigned int)Jet::nBTagAlgos; ++iBtag) {
+    newJet->SetBJetTagsDisc(matchedJet->BJetTagsDisc(iBtag),iBtag);
+  }
+  return;
+}
+
+
+template<typename JETTYPE> void PuppiJetMod<JETTYPE>::RunMatching(FatJet *newJet) {
+  // dR matches a new jet with an existing collection
+  const FatJet *matchedJet = 0;
+  float bestDR2 = 999;
+  for (unsigned int iJ=0; iJ!=fMatchingJets->GetEntries(); ++iJ) {
+    // do dR Matching
+    const FatJet *tmpJet = dynamic_cast<const FatJet*>(fMatchingJets->At(iJ));
+    float dR2 = MathUtils::DeltaR2<const FatJet, FatJet>(tmpJet,newJet);
+    if (dR2<bestDR2) {
+      matchedJet = tmpJet;
+      bestDR2 = dR2;
+    }
+  }
+  if (matchedJet==NULL) {
+    Info("Process","Warning, could not match Puppi jet to a fatjet");
+    return;
+  }
+
+  // copy btags
+  for (unsigned int iBtag=0; iBtag!=(unsigned int)Jet::nBTagAlgos; ++iBtag) {
+    newJet->SetBJetTagsDisc(matchedJet->BJetTagsDisc(iBtag),iBtag);
+  }
+  // copy fatjet b-tagging infos
+  newJet->SetTau1IVF(matchedJet->Tau1IVF());
+  newJet->SetTau2IVF(matchedJet->Tau2IVF());
+  newJet->SetTau3IVF(matchedJet->Tau3IVF());
+  newJet->SetTauDot(matchedJet->tauDot());
+  newJet->SetZRatio(matchedJet->zRatio());
+
+  for (int i=0; i!=3; ++i)  
+    newJet->AddTauIVFAxis(matchedJet->GetTauIVFAxis(i));
+  
+  for (FatJet::TrackData track : matchedJet->GetTrackData()) 
+    newJet->AddTrackData(&track);
+  for (FatJet::SVData sv : matchedJet->GetSVData()) 
+    newJet->AddSVData(&sv);
+  for (FatJet::LeptonData lep : matchedJet->GetElectronData())
+    newJet->AddElectronData(&lep);
+  for (FatJet::LeptonData lep : matchedJet->GetMuonData())
+    newJet->AddMuonData(&lep);
+  
+  for (float sjBtag : matchedJet->GetSubJetBtags())
+    newJet->AddSubJetBtag(sjBtag);
+
+  return;
+}
+
+//--------------------------------------------------------------------------------------------------
+template<typename JETTYPE> void PuppiJetMod<JETTYPE>::SlaveBegin()
+{
+  // Run startup code on the computer (slave) doing the actual analysis.
+    
+  // Create the new output collection
+  fJets = new Array<JETTYPE>(16,fJetsName);
+  
+  // Publish collection for further usage in the analysis
+  if (fPublishOutput)
+    PublishObj(fJets);
+  
+  if (fJetAlgorithm==kCambridgeAachen)
+    fJetDef = new fastjet::JetDefinition(fastjet::cambridge_algorithm, fR0);
+  else if (fJetAlgorithm==kKT)
+    fJetDef = new fastjet::JetDefinition(fastjet::kt_algorithm, fR0);
+  else
+    fJetDef = new fastjet::JetDefinition(fastjet::antikt_algorithm,fR0);
+
+  // Initialize area caculation (done with ghost particles)
+  int activeAreaRepeats = 1;
+  double ghostArea = 0.01;
+  double ghostEtaMax = 7.0;
+  fActiveArea = new fastjet::GhostedAreaSpec(ghostEtaMax,activeAreaRepeats,ghostArea);
+  fAreaDefinition = new fastjet::AreaDefinition(fastjet::active_area_explicit_ghosts,*fActiveArea);
+
+
+  fStopwatch = new TStopwatch();
+
+  return;
+}
+
+//--------------------------------------------------------------------------------------------------
+template<typename JETTYPE> void PuppiJetMod<JETTYPE>::SlaveTerminate()
+{
+  RetractObj(fJets->GetName());
+
+  if (fJets)
+    delete fJets;
+
+  if (fJetDef)
+    delete fJetDef;
+
+  if (fActiveArea)
+    delete fActiveArea;
+  if (fAreaDefinition)
+    delete fAreaDefinition;
+
+  if (fStopwatch)
+    delete fStopwatch;
+}
+
+


### PR DESCRIPTION
- FatJetExtenderMod changes are mostly user-friendliness:
  - Improved debugging and timing tools, set off by default
  - Expensive calculations are set off by default
- Addition of PuppiJetMod:
  - Takes in a collection of PFCandidates (i.e from PuppiMod)
  - Outputs a collection of PFJets or FatJets
  - User can request dR-matching to an existing collection of jets in order to recover b-tagging
