### PR TITLE
Inverted Puppi and Lepton removal

### DIFF
--- a/Mods/interface/PuppiMod.h
+++ b/Mods/interface/PuppiMod.h
@@ -44,6 +44,7 @@ namespace mithep
       void SetRMSScaleFactor( Double_t fact )                { fRMSScaleFactor = fact;         }
       void SetTrackUncertainty( Double_t sig )               { fTrackUncertainty = sig;        }
 
+      void SetNoLepton( Bool_t nolep )                       { fNoLepton = nolep;              }
       void SetKeepPileup( Bool_t keep )                      { fKeepPileup = keep;             }
       void SetInvert( Bool_t invert )                        { fInvert = invert;               }
       void SetApplyCHS( Bool_t apply )                       { fApplyCHS = apply;              }
@@ -88,6 +89,7 @@ namespace mithep
       Double_t fRMSScaleFactor;                      // A scale factor for RMS
       Double_t fTrackUncertainty;                    // The experimental uncertainty in the track fit to vertex distance
 
+      Bool_t   fNoLepton;                            // If set as true, don't use leptons in Puppi
       Bool_t   fKeepPileup;                          // Keep pileup with zero weight (for debugging)
       Bool_t   fInvert;                              // Option to invert weights
       Bool_t   fApplyCHS;                            // This will force weights to 0 or 1 for tracked particles

--- a/Mods/interface/PuppiMod.h
+++ b/Mods/interface/PuppiMod.h
@@ -30,6 +30,7 @@ namespace mithep
       const char   *GetVertexesName()              const     { return fVertexesName;           }
       const char   *GetInputName()                 const     { return fPFCandidatesName;       }   
       const char   *GetOutputName()                const     { return fPuppiParticlesName;     }
+      const char   *GetInvertedName()              const     { return fInvertedParticlesName;  }
       void SetEtaConfigName( const char *name )              { fEtaConfigName = name;          }
       void SetVertexesName( const char *name )               { fVertexesName = name;           }
       void SetInputName( const char *name )                  { fPFCandidatesName = name;       }
@@ -55,7 +56,7 @@ namespace mithep
       void SetApplyLowPUCorr( Bool_t apply )                 { fApplyLowPUCorr = apply;        }
       void SetUseEtaForAlgo( Bool_t use )                    { fUseEtaForAlgo = use;           }
       void SetEtaForAlgo( Double_t eta )                     { fEtaForAlgo = eta;              }
-      void setBothPVandPU( Bool_t both )                     { fBothPVandPU = both;            }
+      void SetBothPVandPU( Bool_t both )                     { fBothPVandPU = both;            }
       void SetDump( Bool_t dump )                            { fDumpingPuppi = dump;           }
 
     protected:

--- a/Mods/interface/PuppiMod.h
+++ b/Mods/interface/PuppiMod.h
@@ -79,6 +79,7 @@ namespace mithep
       TString               fInvertedParticlesName;  // Name of Inverted Puppi Particle collection (output) if putting out both
 
       PFCandidateArr       *fPuppiParticles;         // The output collection for publishing
+      PFCandidateArr       *fInvertedParticles;      // The inverted output, if asking for both
 
       Double_t fRMin;                                // Minimum dR cut for summing up surrounding particles
       Double_t fR0;                                  // Maximum dR cut for summing up surrounding particles

--- a/Mods/interface/PuppiMod.h
+++ b/Mods/interface/PuppiMod.h
@@ -34,6 +34,7 @@ namespace mithep
       void SetVertexesName( const char *name )               { fVertexesName = name;           }
       void SetInputName( const char *name )                  { fPFCandidatesName = name;       }
       void SetOutputName( const char *name )                 { fPuppiParticlesName = name;     }
+      void SetInvertedName( const char *name )               { fInvertedParticlesName = name;  }
 
       void SetRMin( Double_t RMin )                          { fRMin = RMin;                   }
       void SetR0( Double_t R0 )                              { fR0 = R0;                       }
@@ -54,6 +55,7 @@ namespace mithep
       void SetApplyLowPUCorr( Bool_t apply )                 { fApplyLowPUCorr = apply;        }
       void SetUseEtaForAlgo( Bool_t use )                    { fUseEtaForAlgo = use;           }
       void SetEtaForAlgo( Double_t eta )                     { fEtaForAlgo = eta;              }
+      void setBothPVandPU( Bool_t both )                     { fBothPVandPU = both;            }
       void SetDump( Bool_t dump )                            { fDumpingPuppi = dump;           }
 
     protected:
@@ -65,6 +67,7 @@ namespace mithep
       TString               fVertexesName;           // Name of vertices collection used for PV
       TString               fPFCandidatesName;       // Name of PFCandidate collection (input)
       TString               fPuppiParticlesName;     // Name of Puppi Particle collection (output)
+      TString               fInvertedParticlesName;  // Name of Inverted Puppi Particle collection (output) if putting out both
 
       const VertexCol      *fVertexes;               // Vertex branch
       const PFCandidateCol *fPFCandidates;           // Particle flow branch
@@ -89,6 +92,7 @@ namespace mithep
       Bool_t   fApplyLowPUCorr;                      // This will cause a correction when lots of PV particles fall below median
       Bool_t   fUseEtaForAlgo;                       // Determines if you use eta cut or PFType to determine algorithm use
       Double_t fEtaForAlgo;                          // Eta cut to switch algorithms, if you want it
+      Bool_t   fBothPVandPU;                         // Bool set to output PUPPI and inverted PUPPI
       Bool_t   fDumpingPuppi;                        // If this is true, we dump particle information and weights
 
       // These are parameters that are functions of Eta hopefully we can be more clever some day

--- a/Mods/src/PuppiMod.cc
+++ b/Mods/src/PuppiMod.cc
@@ -197,22 +197,22 @@ PuppiMod::Process()
   PFCandidateCol* pfCandidates = NULL;
   PFCandidateArr* leptonCandidates = NULL;
 
-  if (fNoLeptons) {                                                                         // This is the default behavior of Puppi
+  if (fNoLepton) {                                                                              // This is the default behavior of Puppi
     PFCandidateArr* tempCandidates = new PFCandidateArr(16);
 
     for (UInt_t iCand = 0; iCand < inPfCandidates->GetEntries(); iCand++) { 
       auto* cand = pfCandidates->At(iCand);
-      if (cand->pfType != PFCandidate::eMuon && cand->pfType != PFCandidate::eElectron) {   // Take out leptons
+      if (cand->PFType() != PFCandidate::eMuon && cand->PFType() != PFCandidate::eElectron) {   // Take out leptons
         PFCandidate *tempParticle = tempCandidates->Allocate();
         new (tempParticle) PFCandidate(*cand);
       }
       else {
-        PFCandidate *tempParticle = leptonCandidates->Allocate();                           // Store them to add back at the end
+        PFCandidate *tempParticle = leptonCandidates->Allocate();                               // Store them to add back at the end
         new (tempParticle) PFCandidate(*cand);
       }
     }
 
-    tempCandiates->Trim();
+    tempCandidates->Trim();
     leptonCandidates->Trim();
     pfCandidates = tempCandidates;
   }
@@ -491,7 +491,7 @@ PuppiMod::Process()
     }
   }
 
-  if (fNoLeptons) {                                                    // If no leptons were used, add them back in
+  if (fNoLepton) {                                                    // If no leptons were used, add them back in
     for (UInt_t iLepton = 0; iLepton < leptonCandidates->GetEntries(); iLepton++) {
       auto* cand = leptonCandidates->At(iLepton);
       if (GetParticleType(cand, pv) != kChargedPU) {                   // From PV, simply add with weight 1

--- a/Mods/src/PuppiMod.cc
+++ b/Mods/src/PuppiMod.cc
@@ -173,6 +173,8 @@ void
 PuppiMod::SlaveTerminate()
 {
   // ===== deallocate memory ====
+  RetractObj(fPuppiParticles->GetName());
+  delete fPuppiParticles;
   delete fMapper;
 }
 
@@ -467,8 +469,8 @@ PuppiMod::Process()
     InvertedParticles->Trim();
     AddObjThisEvt(InvertedParticles);
   }
+  else
+    delete InvertedParticles;
   
   fPuppiParticles->Trim();
-  // PFCandidateArr *PuppiParticles = (PFCandidateArr*) fPuppiParticles->Clone();
-  // AddObjThisEvt(PuppiParticles);
 }

--- a/Mods/src/PuppiMod.cc
+++ b/Mods/src/PuppiMod.cc
@@ -49,7 +49,6 @@ PuppiMod::PuppiMod(const char *name, const char *title) :
 //--------------------------------------------------------------------------------------------------
 PuppiMod::~PuppiMod()
 {
-  std::cout << "Deleting PuppiMod..." << std::endl;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -174,7 +173,6 @@ void
 PuppiMod::SlaveTerminate()
 {
   // ===== deallocate memory ====
-  delete fPuppiParticles;
   delete fMapper;
 }
 

--- a/Mods/src/PuppiMod.cc
+++ b/Mods/src/PuppiMod.cc
@@ -198,10 +198,11 @@ PuppiMod::Process()
   PFCandidateArr* leptonCandidates = NULL;
 
   if (fNoLepton) {                                                                              // This is the default behavior of Puppi
+    leptonCandidates = new PFCandidateArr(16);
     PFCandidateArr* tempCandidates = new PFCandidateArr(16);
 
     for (UInt_t iCand = 0; iCand < inPfCandidates->GetEntries(); iCand++) { 
-      auto* cand = pfCandidates->At(iCand);
+      auto* cand = inPfCandidates->At(iCand);
       if (cand->PFType() != PFCandidate::eMuon && cand->PFType() != PFCandidate::eElectron) {   // Take out leptons
         PFCandidate *tempParticle = tempCandidates->Allocate();
         new (tempParticle) PFCandidate(*cand);


### PR DESCRIPTION
I've added the option to "invert" Puppi, which means PU is kept in a separate PFCandidate collection. This is useful for things like MET studies. I also added the option to remove leptons before doing Puppi calculations and adding them back in at the end. This is enabled by default since that's the new CMSSW approach. It makes sense as far as physics goes.
