### PR TITLE
JetId expansion

### DIFF
--- a/Mods/interface/JetIdMod.h
+++ b/Mods/interface/JetIdMod.h
@@ -12,6 +12,7 @@
 #include "MitPhysics/Mods/interface/IdMod.h"
 
 #include "MitAna/DataTree/interface/Jet.h"
+#include "MitPhysics/Utils/interface/JetTools.h"
 #include "MitPhysics/Utils/interface/JetIDMVA.h"
 
 namespace mithep {
@@ -32,7 +33,7 @@ namespace mithep {
     Double_t    GetMinNeutralEMFraction() const     { return fMinNeutralEMFraction; }
     Double_t    GetMaxNeutralEMFraction() const     { return fMaxNeutralEMFraction; }
     Bool_t      GetApplyBetaCut() const             { return fApplyBetaCut; }
-    Bool_t      GetApplyPFLooseId() const           { return fApplyPFLooseId; }
+    Bool_t      GetPFId() const                     { return fPFId; }
     UInt_t      GetMVATrainingSet() const           { return fMVATrainingSet; }
     UInt_t      GetMVACutWP() const                 { return fMVACutWP; }
     char const* GetMVAWeightsFile() const           { return fMVAWeightsFile; }
@@ -51,7 +52,7 @@ namespace mithep {
     void SetMinNeutralEMFraction(Double_t m)     { fMinNeutralEMFraction = m; }
     void SetMaxNeutralEMFraction(Double_t m)     { fMaxNeutralEMFraction = m; }
     void SetApplyBetaCut(Bool_t b)               { fApplyBetaCut = b; }
-    void SetApplyPFLooseId(Bool_t b)             { fApplyPFLooseId = b; }
+    void SetPFId(UInt_t w)                       { fPFId = w; }
     void SetMVATrainingSet(UInt_t s)             { fMVATrainingSet = s; }
     void SetMVACutWP(UInt_t w)                   { fMVACutWP = w; }
     void SetMVAWeightsFile(char const* n)        { fMVAWeightsFile = n; }
@@ -79,7 +80,7 @@ namespace mithep {
       cNeutralHFrac,
       cChargedEMFrac,
       cNeutralEMFrac,
-      cPFLooseId,
+      cPFId,
       cBeta,
       cMVA,
       nCuts
@@ -99,7 +100,7 @@ namespace mithep {
     Double_t fMinNeutralEMFraction = 0.;
     Double_t fMaxNeutralEMFraction = 1.;
     Bool_t   fApplyBetaCut = kFALSE;          //=true then apply beta cut
-    Bool_t   fApplyPFLooseId = kFALSE;        //=true then apply PF loose ID
+    UInt_t   fPFId = JetTools::nPFIdWorkingPoints; // PF Id working point
     UInt_t   fMVATrainingSet = JetIDMVA::nMVATypes; //JetIDMVA::MVAType
     UInt_t   fMVACutWP = JetIDMVA::kLoose; //JetIDMVA::CutType
     TString  fMVAWeightsFile = "";

--- a/Mods/interface/JetIdMod.h
+++ b/Mods/interface/JetIdMod.h
@@ -12,6 +12,7 @@
 #include "MitPhysics/Mods/interface/IdMod.h"
 
 #include "MitAna/DataTree/interface/Jet.h"
+#include "MitPhysics/Utils/interface/JetTools.h"
 #include "MitPhysics/Utils/interface/JetIDMVA.h"
 
 namespace mithep {
@@ -32,7 +33,7 @@ namespace mithep {
     Double_t    GetMinNeutralEMFraction() const     { return fMinNeutralEMFraction; }
     Double_t    GetMaxNeutralEMFraction() const     { return fMaxNeutralEMFraction; }
     Bool_t      GetApplyBetaCut() const             { return fApplyBetaCut; }
-    Bool_t      GetApplyPFLooseId() const           { return fApplyPFLooseId; }
+    Bool_t      GetPFId() const                     { return fPFId; }
     UInt_t      GetMVATrainingSet() const           { return fMVATrainingSet; }
     UInt_t      GetMVACutWP() const                 { return fMVACutWP; }
     char const* GetMVAWeightsFile() const           { return fMVAWeightsFile; }
@@ -53,7 +54,7 @@ namespace mithep {
     void SetMaxMuonFraction(Double_t m)          { fMaxMuonFraction = m; }
     void SetMinMuonFraction(Double_t m)          { fMinMuonFraction = m; }
     void SetApplyBetaCut(Bool_t b)               { fApplyBetaCut = b; }
-    void SetApplyPFLooseId(Bool_t b)             { fApplyPFLooseId = b; }
+    void SetPFId(UInt_t w)                       { fPFId = w; }
     void SetMVATrainingSet(UInt_t s)             { fMVATrainingSet = s; }
     void SetMVACutWP(UInt_t w)                   { fMVACutWP = w; }
     void SetMVAWeightsFile(char const* n)        { fMVAWeightsFile = n; }
@@ -88,7 +89,7 @@ namespace mithep {
       cMuonFrac,
       cNPFCandidates,
       cNChargedPFCandidates,
-      cPFLooseId,
+      cPFId,
       cBeta,
       cMVA,
       nCuts
@@ -112,7 +113,7 @@ namespace mithep {
     UInt_t   fMinNPFCandidates = 0;
     UInt_t   fMinNChargedPFCandidates = 0;
     Bool_t   fApplyBetaCut = kFALSE;          //=true then apply beta cut
-    Bool_t   fApplyPFLooseId = kFALSE;        //=true then apply PF loose ID
+    UInt_t   fPFId = JetTools::nPFIdWorkingPoints; // PF Id working point
     UInt_t   fMVATrainingSet = JetIDMVA::nMVATypes; //JetIDMVA::MVAType
     UInt_t   fMVACutWP = JetIDMVA::kLoose; //JetIDMVA::CutType
     TString  fMVAWeightsFile = "";

--- a/Mods/python/FatJetExtenderMod.py
+++ b/Mods/python/FatJetExtenderMod.py
@@ -1,5 +1,4 @@
 from MitAna.TreeMod.bambu import mithep
-import os
 
 fatJetExtenderMod = mithep.FatJetExtenderMod(
     InputName = "FatJets",

--- a/Mods/python/JetIdMod.py
+++ b/Mods/python/JetIdMod.py
@@ -4,7 +4,7 @@ import os
 jetIdMod = mithep.JetIdMod(
     InputName = mithep.ModNames.gkCorrectedJetsName,
     OutputName = 'GoodJets',
-    ApplyPFLooseId = True,
+    PFId = mithep.JetTools.kPFLoose,
     MVATrainingSet = mithep.JetIDMVA.k53BDTCHSFullPlusRMS, # set to mithep.JetIDMVA.nMVATrainingTypes to turn off MVA
     MVACutWP = mithep.JetIDMVA.kLoose,
     MVAWeightsFile = os.environ['MIT_DATA'] + '/TMVAClassification_5x_BDT_chsFullPlusRMS.weights.xml',

--- a/Mods/src/ElectronCorrectionMod.cc
+++ b/Mods/src/ElectronCorrectionMod.cc
@@ -3,6 +3,7 @@
 #include <TNtuple.h>
 #include "MitAna/DataTree/interface/Names.h"
 #include "MitAna/DataTree/interface/ElectronCol.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 #include "MitPhysics/Init/interface/ModNames.h"
 #include "MitPhysics/Mods/interface/ElectronCorrectionMod.h"
 

--- a/Mods/src/ElectronIDModRun1.cc
+++ b/Mods/src/ElectronIDModRun1.cc
@@ -6,6 +6,7 @@
 #include "MitAna/DataTree/interface/TriggerObjectCol.h"
 #include "MitAna/DataTree/interface/DecayParticleCol.h"
 #include "MitAna/DataTree/interface/PFCandidateCol.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 #include "MitPhysics/Init/interface/ModNames.h"
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"

--- a/Mods/src/JetIDModRun1.cc
+++ b/Mods/src/JetIDModRun1.cc
@@ -88,7 +88,7 @@ mithep::JetIDModRun1::Process()
       if (fApplyBetaCut && !JetTools::PassBetaVertexAssociationCut(pfJet, inVertices->At(0), inVertices, 0.2))
         continue;
 
-      if (fApplyPFLooseId && !JetTools::passPFLooseId(pfJet))
+      if (fApplyPFLooseId && !JetTools::passPFId(pfJet, JetTools::kPFLoose))
         continue;
       
       if (fApplyMVACut && !fJetIDMVA->pass(pfJet, inVertices->At(0), inVertices))

--- a/Mods/src/JetIdMod.cc
+++ b/Mods/src/JetIdMod.cc
@@ -1,5 +1,4 @@
 #include "MitPhysics/Mods/interface/JetIdMod.h"
-#include "MitPhysics/Utils/interface/JetTools.h"
 #include "MitPhysics/Utils/interface/JetIDMVA.h"
 #include "MitAna/DataTree/interface/CaloJet.h"
 #include "MitAna/DataTree/interface/PFJet.h"
@@ -46,7 +45,7 @@ mithep::JetIdMod::IdBegin()
   xaxis->SetBinLabel(cMuonFrac + 1, "muonFraction");
   xaxis->SetBinLabel(cNPFCandidates + 1, "nPFCandidates");
   xaxis->SetBinLabel(cNChargedPFCandidates + 1, "nChargedPFCandidates");
-  xaxis->SetBinLabel(cPFLooseId + 1, "PFLooseId");
+  xaxis->SetBinLabel(cPFId + 1, "PFId");
   xaxis->SetBinLabel(cBeta + 1, "Beta");
   xaxis->SetBinLabel(cMVA + 1, "MVA");
 }
@@ -120,9 +119,9 @@ mithep::JetIdMod::IsGood(mithep::Jet const& jet)
       return false;
     fCutFlow->Fill(cNChargedPFCandidates);
 
-    if (fApplyPFLooseId && !JetTools::passPFLooseId(pfJet))
+    if (fPFId != JetTools::nPFIdWorkingPoints && !JetTools::passPFId(pfJet, JetTools::PFIdWorkingPoint(fPFId)))
       return false;
-    fCutFlow->Fill(cPFLooseId);
+    fCutFlow->Fill(cPFId);
 
     if (fApplyBetaCut && !JetTools::PassBetaVertexAssociationCut(pfJet, GetVertices()->At(0), GetVertices(), 0.2))
       return false;

--- a/Mods/src/JetIdMod.cc
+++ b/Mods/src/JetIdMod.cc
@@ -1,5 +1,4 @@
 #include "MitPhysics/Mods/interface/JetIdMod.h"
-#include "MitPhysics/Utils/interface/JetTools.h"
 #include "MitPhysics/Utils/interface/JetIDMVA.h"
 #include "MitAna/DataTree/interface/CaloJet.h"
 #include "MitAna/DataTree/interface/PFJet.h"
@@ -43,7 +42,7 @@ mithep::JetIdMod::IdBegin()
   xaxis->SetBinLabel(cNeutralHFrac + 1, "neutralHadronFraction");
   xaxis->SetBinLabel(cChargedEMFrac + 1, "chargedEMFraction");
   xaxis->SetBinLabel(cNeutralEMFrac + 1, "neutralEMFraction");
-  xaxis->SetBinLabel(cPFLooseId + 1, "PFLooseId");
+  xaxis->SetBinLabel(cPFId + 1, "PFId");
   xaxis->SetBinLabel(cBeta + 1, "Beta");
   xaxis->SetBinLabel(cMVA + 1, "MVA");
 }
@@ -104,9 +103,9 @@ mithep::JetIdMod::IsGood(mithep::Jet const& jet)
       return false;
     fCutFlow->Fill(cNeutralEMFrac);
 
-    if (fApplyPFLooseId && !JetTools::passPFLooseId(pfJet))
+    if (fPFId != JetTools::nPFIdWorkingPoints && !JetTools::passPFId(pfJet, JetTools::PFIdWorkingPoint(fPFId)))
       return false;
-    fCutFlow->Fill(cPFLooseId);
+    fCutFlow->Fill(cPFId);
 
     if (fApplyBetaCut && !JetTools::PassBetaVertexAssociationCut(pfJet, GetVertices()->At(0), GetVertices(), 0.2))
       return false;

--- a/Mods/src/MuonIDModRun1.cc
+++ b/Mods/src/MuonIDModRun1.cc
@@ -3,6 +3,7 @@
 #include "MitAna/DataTree/interface/MuonFwd.h"
 #include "MitAna/DataTree/interface/ElectronFwd.h"
 #include "MitAna/DataTree/interface/VertexCol.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 #include "MitPhysics/Init/interface/ModNames.h"
 
 #include "TSystem.h"

--- a/Mods/src/PhotonCiCMod.cc
+++ b/Mods/src/PhotonCiCMod.cc
@@ -1,6 +1,7 @@
 #include <TNtuple.h>
 #include <TRandom3.h>
 #include "MitAna/DataTree/interface/PhotonCol.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 #include "MitPhysics/Init/interface/ModNames.h"
 #include "MitPhysics/Utils/interface/IsolationTools.h"
 #include "MitPhysics/Utils/interface/PhotonTools.h"

--- a/Mods/src/PhotonIDModRun1.cc
+++ b/Mods/src/PhotonIDModRun1.cc
@@ -1,5 +1,6 @@
 #include "MitPhysics/Mods/interface/PhotonIDModRun1.h"
 #include "MitAna/DataTree/interface/PhotonCol.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 #include "MitPhysics/Init/interface/ModNames.h"
 #include "MitPhysics/Utils/interface/IsolationTools.h"
 #include "MitPhysics/Utils/interface/PhotonTools.h"

--- a/Mods/src/PhotonPairSelector.cc
+++ b/Mods/src/PhotonPairSelector.cc
@@ -5,6 +5,7 @@
 #include "MitAna/DataTree/interface/StableData.h"
 #include "MitAna/DataTree/interface/StableParticle.h"
 #include "MitAna/DataTree/interface/DecayParticleFwd.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 #include "MitPhysics/Init/interface/ModNames.h"
 #include "MitPhysics/Utils/interface/IsolationTools.h"
 #include "MitPhysics/Utils/interface/PhotonTools.h"

--- a/Mods/src/PhotonTreeWriter.cc
+++ b/Mods/src/PhotonTreeWriter.cc
@@ -5,6 +5,7 @@
 #include "MitAna/DataTree/interface/StableData.h"
 #include "MitAna/DataTree/interface/StableParticle.h"
 #include "MitAna/DataTree/interface/PFMet.h"
+#include "MitAna/DataTree/interface/EventHeader.h"
 #include "MitPhysics/Init/interface/ModNames.h"
 #include "MitPhysics/Utils/interface/IsolationTools.h"
 #include "MitPhysics/Utils/interface/PhotonTools.h"

--- a/Utils/interface/JetTools.h
+++ b/Utils/interface/JetTools.h
@@ -21,6 +21,13 @@ namespace mithep {
 
   class JetTools {
   public:
+    enum PFIdWorkingPoint {
+      kPFLoose,
+      kPFTight,
+      kPFTightLepVeto,
+      nPFIdWorkingPoints
+    };
+
     JetTools();
     virtual ~JetTools();
     
@@ -55,7 +62,7 @@ namespace mithep {
     static Double_t           frac(const PFJet *iJet,Double_t iDRMax,Double_t iDRMin,Int_t iPFType);
     static Double_t           betaStar(const PFJet *iJet,const Vertex *iVertex,const VertexCol* iVertices,
 				       Double_t iDZCut=0.2);
-    static Bool_t             passPFLooseId(const PFJet *iJet);
+    static Bool_t             passPFId(const PFJet *iJet, PFIdWorkingPoint);
     static double             W(const PFJet *iJet,int iPFType,int iType);
     ClassDef(JetTools, 1)
   };

--- a/Utils/src/JetIDMVA.cc
+++ b/Utils/src/JetIDMVA.cc
@@ -199,7 +199,7 @@ JetIDMVA::pass(const PFJet *iJet, const Vertex *iVertex, const VertexCol *iVerti
   if (lEta > 4.99)
     return false;
 
-  if(!JetTools::passPFLooseId(iJet))
+  if(!JetTools::passPFId(iJet, JetTools::kPFLoose))
     return false;
 
   double lPt = iJet->Pt(); // use corrected Pt
@@ -251,7 +251,7 @@ JetIDMVA::MVAValue(const PFJet *iJet, const Vertex *iVertex, //Vertex here is th
   if (iJet->Corrections() != fgCorrectionMask)
     throw std::runtime_error("JetIDMVA works only with L1+L2+L3 corrected jets");
 
-  if (!JetTools::passPFLooseId(iJet))
+  if (!JetTools::passPFId(iJet, JetTools::kPFLoose))
     return -2.;
 
   //set all input variables
@@ -309,7 +309,7 @@ JetIDMVA::QGValue(const PFJet *iJet, const Vertex *iVertex, //Vertex here is the
     std::cout << "Error: JetIDMVA not properly initialized.\n";
     return lId;
   }
-  if (!JetTools::passPFLooseId(iJet))
+  if (!JetTools::passPFId(iJet, JetTools::kPFLoose))
     return lId;
 
   fVariables[kJetPt]       = iJet->Pt();

--- a/Utils/src/MVAMet.cc
+++ b/Utils/src/MVAMet.cc
@@ -395,7 +395,7 @@ Met MVAMet::GetMet(	Bool_t iPhi,
   for(unsigned int i0 = 0; i0 < iJets->GetEntries(); i0++) {
     const PFJet *pJet = iJets->At(i0);
     Double_t pPt = pJet->Pt();
-    if(!JetTools::passPFLooseId(pJet)) continue;
+    if(!JetTools::passPFId(pJet, JetTools::kPFLoose)) continue;
     if(f42 && pPt > 1.) lNAllJet++;
     if(!f42)            lNAllJet++;
     if(pPt  > 30.)  lNJet++;
@@ -570,7 +570,7 @@ Met MVAMet::GetMet(	Bool_t iPhi,
     double pDPhi2 = fabs(pJet->Phi() - iPhi2); if(pDPhi2 > 2.*TMath::Pi()-pDPhi2) pDPhi2 = 2.*TMath::Pi()-pDPhi2;
     double pDR2   = sqrt(pDEta2*pDEta2 + pDPhi2*pDPhi2);
     if(pDR2 < 0.5) continue;  
-    if(!JetTools::passPFLooseId(pJet)) continue;
+    if(!JetTools::passPFId(pJet, JetTools::kPFLoose)) continue;
     if(f42 && pPt > 1.) lNAllJet++;
     if(!f42)            lNAllJet++;
     if(pPt  > 30.)  lNJet++;

--- a/Utils/src/RecoilTools.cc
+++ b/Utils/src/RecoilTools.cc
@@ -310,7 +310,7 @@ Met RecoilTools::PUCMet( const PFJetCol       *iJets,const PFCandidateCol *iCand
 
   for (UInt_t i0 = 0; i0 < iJets->GetEntries(); i0++) {
     const PFJet *pJet = iJets->At(i0);
-    if (!JetTools::passPFLooseId(pJet))
+    if (!JetTools::passPFId(pJet, JetTools::kPFLoose))
       continue;
     if (fJetIDMVA->pass(pJet,iVertex,iVertices))
       continue;
@@ -368,7 +368,7 @@ Met RecoilTools::PUMet(const PFJetCol *iJets, const PFCandidateCol *iCands,const
   }
   for (UInt_t i0 = 0; i0 < iJets->GetEntries(); i0++) {
     const PFJet *pJet = iJets->At(i0);
-    if (!JetTools::passPFLooseId(pJet))
+    if (!JetTools::passPFId(pJet, JetTools::kPFLoose))
       continue;
     if (!filter(pJet,iPhi1,iEta1,iPhi2,iEta2))
       continue; //Quick cleaning

--- a/bin/getJEC.py
+++ b/bin/getJEC.py
@@ -1,3 +1,6 @@
+## getJECLocal
+## Run this script as a CMSSW job to dump the JEC constants into text files from the conditions DB.
+
 import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 
@@ -5,6 +8,7 @@ import sys
 
 options = VarParsing('analysis')
 options.register('globalTag', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'global tag')
+options.register('jecTag', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'JEC tag (optional - only used for output file names)')
 options.register('payload', default = 'AK4PFchs', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'DB payload name')
 
 options.parseArguments()
@@ -12,6 +16,9 @@ options.parseArguments()
 if not options.globalTag:
     print 'Global tag not set'
     sys.exit(1)
+
+if not options.jecTag:
+    options.jecTag = options.globalTag
 
 process = cms.Process("JEC")
 
@@ -26,7 +33,7 @@ process.saveCorrections = cms.EDAnalyzer('JetCorrectorDBReader',
     payloadName    = cms.untracked.string(options.payload),
     printScreen    = cms.untracked.bool(True),
     createTextFile = cms.untracked.bool(True),
-    globalTag      = cms.untracked.string(options.globalTag)
+    globalTag      = cms.untracked.string(options.jecTag)
 )
 
 process.p = cms.Path(

--- a/bin/getJECLocal.py
+++ b/bin/getJECLocal.py
@@ -1,0 +1,57 @@
+## getJECLocal
+## Run this script as a CMSSW job to dump the JEC constants into text files from sqlite files provided by the JetMET group.
+
+import FWCore.ParameterSet.Config as cms
+from FWCore.ParameterSet.VarParsing import VarParsing
+
+import sys
+
+options = VarParsing('analysis')
+options.register('source', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'source sqlite file')
+options.register('jecTag', default = 'Summer15_50nsV5_DATA_AK4PF', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'payload tag')
+options.register('payload', default = 'AK4PF', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'DB payload name')
+
+options.parseArguments()
+
+if not options.source:
+    print 'Source not given'
+    sys.exit(1)
+
+if '/' in options.source:
+    print 'Source sqlite file must be in the current directory (cannot have / in path name).'
+    sys.exit(1)
+
+process = cms.Process("JEC")
+
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+from CondCore.DBCommon.CondDBSetup_cfi import *
+process.jec = cms.ESSource("PoolDBESSource",
+    DBParameters = cms.PSet(
+        messageLevel = cms.untracked.int32(0)
+    ),
+    timetype = cms.string('runnumber'),
+    toGet = cms.VPSet(
+        cms.PSet(
+            record = cms.string('JetCorrectionsRecord'),
+            tag    = cms.string('JetCorrectorParametersCollection_' + options.jecTag),
+            label  = cms.untracked.string(options.payload)
+        ),
+    ), 
+    connect = cms.string('sqlite:' + options.source)
+)
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1))
+
+process.load('Configuration.StandardSequences.Services_cff')
+
+process.saveCorrections = cms.EDAnalyzer('JetCorrectorDBReader', 
+    payloadName    = cms.untracked.string(options.payload),
+    printScreen    = cms.untracked.bool(True),
+    createTextFile = cms.untracked.bool(True),
+    globalTag      = cms.untracked.string(options.jecTag)
+)
+
+process.p = cms.Path(
+    process.saveCorrections
+)


### PR DESCRIPTION
Adding "medium" PFJet Id and more switches and dials to JetIdMod. We have to be careful not to add too many of those though; one big reason we rewrote our Id modules from scratch was that the Run 1 modules had too many switches that it was getting difficult to use.
