### PR TITLE
More fatjet optimizations

### DIFF
--- a/Mods/interface/FatJetExtenderMod.h
+++ b/Mods/interface/FatJetExtenderMod.h
@@ -18,7 +18,7 @@
 #include "fastjet/ClusterSequenceArea.hh"
 #include "fastjet/tools/Pruner.hh"
 #include "fastjet/tools/Filter.hh"
-#include "fastjet/contrib/Nsubjettiness.hh"
+#include "fastjet/contrib/Njettiness.hh"
 #include "fastjet/contrib/SoftDrop.hh"
 #include "fastjet/contrib/EnergyCorrelator.hh"
 
@@ -112,7 +112,7 @@ namespace mithep
       double fMicrojetConeSize = -1.0;
 
       double GetQjetVolatility (VPseudoJet const& constits, int QJetsN = 25, int seed = 12345);
-      void GetJetConstituents(fastjet::PseudoJet const&, VPseudoJet&, float);
+      VPseudoJet FilterJetsByPt(VPseudoJet const&, double ptMin);
       double FindRMS(std::vector<float>);
       double FindMean(std::vector<float>);
 
@@ -145,10 +145,8 @@ namespace mithep
       TString fXlFatJetsName;              //name of output fXlFatJets collection
       XlFatJetArr* fXlFatJets{0};             //array of fXlFatJets
 
-      fastjet::contrib::Nsubjettiness* fNSub1{0};
-      fastjet::contrib::Nsubjettiness* fNSub2{0};
-      fastjet::contrib::Nsubjettiness* fNSub3{0};
-      fastjet::contrib::Nsubjettiness* fNSub4{0};
+      // used for nsubjettiness calculation
+      fastjet::contrib::Njettiness* fNJettiness{0};
 
       fastjet::contrib::EnergyCorrelatorDoubleRatio* fECR2b0{0};
       fastjet::contrib::EnergyCorrelatorDoubleRatio* fECR2b0p2{0};


### PR DESCRIPTION
- Got rid of four Nsubjettiness calculators and replaced with one Njettiness calculator. Nsubjettiness is a simple wrapper of Njettiness with the "N" parameter; each time Nsubjettiness evaluation is called, a new collection of jet constituents is created and fed to the Njettiness algorithm. We can speed this up by using a single constituents vector and just calling Njettiness with different N. A test on a TTbar file showed a significant reduction in computing time (80s -> 20s for the module, when only tau and various masses are calculated)
- Added an option to either run four SoftDrop calculator or use an in-house version that produces four soft drop jets in one go. Did not completely replace the former with the latter because the hack was not as simple as the case of Nsubjettiness, and the in-house code might get outdated with a future update to the fastjet package.
