### PR TITLE
allowing footprint-removed isolation to run on electrons too

### DIFF
--- a/Utils/interface/IsolationTools.h
+++ b/Utils/interface/IsolationTools.h
@@ -24,6 +24,7 @@
 #include "MitAna/DataTree/interface/PileupEnergyDensityFwd.h"
 #include "MitPhysics/Utils/interface/ElectronTools.h"
 #include "MitPhysics/Utils/interface/MuonTools.h"
+#include "MitPhysics/Utils/interface/PhotonTools.h"
 
 namespace mithep
 {
@@ -73,14 +74,16 @@ namespace mithep
                                                   Double_t dRMax = 0.3, Bool_t isDebug=kFALSE);
     static Double_t PFElectronIsolationRhoCorr(Electron const*, Double_t rho, ElectronTools::EElectronEffectiveAreaTarget);
 
+    static Double_t PFPhotonIsolationRhoCorr(Double_t eta, Double_t iso, Double_t rho, PhotonTools::EPhotonEffectiveAreaTarget, PhotonTools::EPhotonEffectiveAreaType);
+
     static Double_t PFMuonIsolationRhoCorr(Muon const*, Double_t rho, MuonTools::EMuonEffectiveAreaTarget);
 
-    static void PFPhotonIsoFootprintRemoved(Photon const*, Vertex const*, PFCandidateCol const*, Double_t dR, Double_t& chIso, Double_t& nhIso, Double_t& phIso);
+    static void PFEGIsoFootprintRemoved(Particle const*, Vertex const*, PFCandidateCol const*, Double_t dR, Double_t& chIso, Double_t& nhIso, Double_t& phIso);
 
     static Double_t BetaM(const TrackCol *tracks, const Muon *p, const Vertex *vertex, 
                           Double_t ptMin, Double_t  delta_z, Double_t extRadius,
                           Double_t intRadius);
-    static Double_t BetaMwithPUCorrection(const PFCandidateCol *PFNoPileUP, const PFCandidateCol *PFPileUP, const Muon *p, Double_t extRadius);
+    static Double_t BetaMwithPUCorrection(const PFCandidateCol *PFNoPileUP, const PFCandidateCol *PFPileUP, const Muon *p, Double_t extRadius, Double_t* isoArr = 0);
     static Double_t BetaE(const TrackCol *tracks, const Electron *p, const Vertex *vertex, 
                           Double_t ptMin, Double_t  delta_z, Double_t extRadius,
                           Double_t intRadius);

--- a/Utils/src/PhotonTools.cc
+++ b/Utils/src/PhotonTools.cc
@@ -105,7 +105,7 @@ mithep::PhotonTools::PassIsoFootprintRhoCorr(Photon const* pho, EPhIsoType isoTy
   double nhIso = 0.;
   double phIso = 0.;
 
-  IsolationTools::PFPhotonIsoFootprintRemoved(pho, pv, pfCands, 0.3, chIso, nhIso, phIso);
+  IsolationTools::PFEGIsoFootprintRemoved(pho, pv, pfCands, 0.3, chIso, nhIso, phIso);
 
   return PassIsoRhoCorr(pho, isoType, rho, chIso, nhIso, phIso);
 }
@@ -123,14 +123,14 @@ mithep::PhotonTools::PassIsoRhoCorr(Photon const* pho, EPhIsoType isoType, Doubl
   bool isEB = scEta < gkPhoEBEtaMax;
   double pEt = pho->Et();
 
-  double chEA = 0.;
-  double nhEA = 0.;
-  double phEA = 0.;
+  double chIsoCor = 0.;
+  double nhIsoCor = 0.;
+  double phIsoCor = 0.;
 
   if (isoType == kSummer15TightIso || isoType == kSummer15MediumIso || isoType == kSummer15LooseIso) {
-    chEA = PhotonEffectiveArea(kPhoChargedHadron03, scEta, kPhoEAPhys14);
-    nhEA = PhotonEffectiveArea(kPhoNeutralHadron03, scEta, kPhoEAPhys14);
-    phEA = PhotonEffectiveArea(kPhoPhoton03, scEta, kPhoEAPhys14);
+    chIsoCor = IsolationTools::PFPhotonIsolationRhoCorr(scEta, chIso, rho, kPhoEAPhys14, kPhoChargedHadron03);
+    nhIsoCor = IsolationTools::PFPhotonIsolationRhoCorr(scEta, nhIso, rho, kPhoEAPhys14, kPhoNeutralHadron03);
+    phIsoCor = IsolationTools::PFPhotonIsolationRhoCorr(scEta, phIso, rho, kPhoEAPhys14, kPhoPhoton03);
   }
 
   double chIsoCut = 0.;
@@ -157,10 +157,6 @@ mithep::PhotonTools::PassIsoRhoCorr(Photon const* pho, EPhIsoType isoType, Doubl
     break;
   }
 
-  double chIsoCor = TMath::Max(chIso - rho * chEA, 0.0);
-  double nhIsoCor = TMath::Max(nhIso - rho * nhEA , 0.0);
-  double phIsoCor = TMath::Max(phIso - rho * phEA , 0.0);
-  
   if (chIsoCor > chIsoCut)
     return false;
   if (nhIsoCor > nhIsoCut)


### PR DESCRIPTION
footprint-removed isolation works on both e and gamma
muon isolation can return individual sums
