### PR TITLE
Egid fix

### DIFF
--- a/Mods/src/ElectronIdMod.cc
+++ b/Mods/src/ElectronIdMod.cc
@@ -293,9 +293,12 @@ mithep::ElectronIdMod::PassIsolationCut(Electron const& ele)
   case ElectronTools::kSummer15Loose50nsIso:
   case ElectronTools::kSummer15Medium50nsIso:
   case ElectronTools::kSummer15Tight50nsIso:
-    return ElectronTools::PassIsoFootprintRhoCorr(&ele, ElectronTools::EElIsoType(fIsoType),
-                                                  GetPileupEnergyDensity()->At(0)->Rho(fRhoAlgo),
-                                                  GetPFCandidates(), GetVertices()->At(0));
+    // EGM does not apply the footprint correction as of Fall 2015 (Even though everyone admits it is better to do so).
+    // return ElectronTools::PassIsoFootprintRhoCorr(&ele, ElectronTools::EElIsoType(fIsoType),
+    //                                               GetPileupEnergyDensity()->At(0)->Rho(fRhoAlgo),
+    //                                               GetPFCandidates(), GetVertices()->At(0));
+    return ElectronTools::PassIsoRhoCorr(&ele, ElectronTools::EElIsoType(fIsoType),
+                                         GetPileupEnergyDensity()->At(0)->Rho(fRhoAlgo));
 
   case ElectronTools::kNoIso:
     return true;

--- a/Mods/src/ElectronIdMod.cc
+++ b/Mods/src/ElectronIdMod.cc
@@ -281,13 +281,21 @@ mithep::ElectronIdMod::PassIsolationCut(Electron const& ele)
   case ElectronTools::kVBTFWorkingPoint70CombinedIso:
     return ElectronTools::PassCustomIso(&ele, ElectronTools::EElIsoType(fIsoType));
 
+  case ElectronTools::kSummer15FakeIso:
+  case ElectronTools::kSummer15Fake50nsIso:
+    return ElectronTools::PassPFIso(&ele, ElectronTools::EElIsoType(fIsoType));
+
   case ElectronTools::kSummer15VetoIso:
   case ElectronTools::kSummer15LooseIso:
   case ElectronTools::kSummer15MediumIso:
   case ElectronTools::kSummer15TightIso:
-  case ElectronTools::kSummer15FakeIso:
-    return ElectronTools::PassIsoRhoCorr(&ele, ElectronTools::EElIsoType(fIsoType),
-                                         GetPileupEnergyDensity()->At(0)->Rho(fRhoAlgo));
+  case ElectronTools::kSummer15Veto50nsIso:
+  case ElectronTools::kSummer15Loose50nsIso:
+  case ElectronTools::kSummer15Medium50nsIso:
+  case ElectronTools::kSummer15Tight50nsIso:
+    return ElectronTools::PassIsoFootprintRhoCorr(&ele, ElectronTools::EElIsoType(fIsoType),
+                                                  GetPileupEnergyDensity()->At(0)->Rho(fRhoAlgo),
+                                                  GetPFCandidates(), GetVertices()->At(0));
 
   case ElectronTools::kNoIso:
     return true;

--- a/Utils/interface/ElectronTools.h
+++ b/Utils/interface/ElectronTools.h
@@ -97,7 +97,12 @@ namespace mithep {
       kSummer15LooseIso,
       kSummer15MediumIso,
       kSummer15TightIso,
-      kSummer15FakeIso
+      kSummer15FakeIso,
+      kSummer15Veto50nsIso,
+      kSummer15Loose50nsIso,
+      kSummer15Medium50nsIso,
+      kSummer15Tight50nsIso,
+      kSummer15Fake50nsIso
     };
 
     enum EElectronIsoVar {
@@ -160,8 +165,9 @@ namespace mithep {
     static Bool_t       PassCustomIso(const Electron *el, EElIsoType isoType);
     static Bool_t       PassID(Electron const*, EElIdType); // new implementation to get rid of PassCustomID
     static Bool_t       PassIso(Electron const*, EElIsoType); // new implementation to get rid of PassCustomIso
-    static Bool_t       PassPFIso(Electron const*, EElIsoType, PFCandidateCol const*, Vertex const*, MuonCol const* = 0, ElectronCol const* = 0);
-    static Bool_t       PassIsoRhoCorr(Electron const*, EElIsoType, Double_t rho, PFCandidateCol const* = 0, Vertex const* = 0); // new implementation to get rid of PassCustomIso
+    static Bool_t       PassPFIso(Electron const*, EElIsoType, PFCandidateCol const* = 0, Vertex const* = 0, MuonCol const* = 0, ElectronCol const* = 0);
+    static Bool_t       PassIsoRhoCorr(Electron const*, EElIsoType, Double_t rho, PFCandidateCol const* = 0, Vertex const* = 0);
+    static Bool_t       PassIsoFootprintRhoCorr(Electron const*, EElIsoType, Double_t rho, PFCandidateCol const*, Vertex const*);
     static Bool_t       PassD0Cut(Electron const*, VertexCol const*, EElIdType, Int_t iVertex = 0);
     static Bool_t       PassD0Cut(Electron const*, BeamSpotCol const*, EElIdType);
     static Bool_t       PassDZCut(Electron const*, VertexCol const*, EElIdType, Int_t iVertex = 0);

--- a/Utils/interface/IsolationTools.h
+++ b/Utils/interface/IsolationTools.h
@@ -72,7 +72,8 @@ namespace mithep
                                                   const ElectronCol *goodElectrons = 0,
                                                   const MuonCol *goodMuons = 0,
                                                   Double_t dRMax = 0.3, Bool_t isDebug=kFALSE);
-    static Double_t PFElectronIsolationRhoCorr(Electron const*, Double_t rho, ElectronTools::EElectronEffectiveAreaTarget);
+    static Double_t PFEleCombinedIsolationRhoCorr(Electron const*, Double_t rho, ElectronTools::EElectronEffectiveAreaTarget);
+    static Double_t PFEleCombinedIsolationRhoCorr(Double_t chargedIso, Double_t neutralIso, Double_t rho, Double_t eta, ElectronTools::EElectronEffectiveAreaTarget);
 
     static Double_t PFPhotonIsolationRhoCorr(Double_t eta, Double_t iso, Double_t rho, PhotonTools::EPhotonEffectiveAreaTarget, PhotonTools::EPhotonEffectiveAreaType);
 

--- a/Utils/src/ElectronTools.cc
+++ b/Utils/src/ElectronTools.cc
@@ -482,6 +482,31 @@ mithep::ElectronTools::PassIsoRhoCorr(Electron const* ele, EElIsoType isoType, D
   case kPFIso_HggLeptonTag2012HCP:
     return IsolationTools::PFElectronIsolation2012LepTag(ele, vertex, pfCandidates, rho, kEleEAData2012, 0, 0, 0.3) < 0.15;
   default:
+    break;
+  }
+
+  // below: Summer15, without footprint correction
+
+  double combRelIso = IsolationTools::PFEleCombinedIsolationRhoCorr(ele, rho, kEleEASummer15) / ele->Pt();
+
+  switch (isoType) {
+  case kSummer15VetoIso:
+    return combRelIso < (isEB ? 0.1260 : 0.1440);
+  case kSummer15LooseIso:
+    return combRelIso < (isEB ? 0.0893 : 0.1210);
+  case kSummer15MediumIso:
+    return combRelIso < (isEB ? 0.0766 : 0.0678);
+  case kSummer15TightIso:
+    return combRelIso < (isEB ? 0.0354 : 0.0646);
+  case kSummer15Veto50nsIso:
+    return combRelIso < (isEB ? 0.161 : 0.193);
+  case kSummer15Loose50nsIso:
+    return combRelIso < (isEB ? 0.118 : 0.118);
+  case kSummer15Medium50nsIso:
+    return combRelIso < (isEB ? 0.0987 : 0.0902);
+  case kSummer15Tight50nsIso:
+    return combRelIso < (isEB ? 0.0591 : 0.0759);
+  default:
     return false;
   }
 }

--- a/Utils/src/ElectronTools.cc
+++ b/Utils/src/ElectronTools.cc
@@ -329,88 +329,93 @@ Bool_t ElectronTools::PassCustomIso(const Electron *ele, EElIsoType isoType)
 Bool_t
 mithep::ElectronTools::PassID(Electron const* ele, EElIdType type)
 {
-  if (type >= kSummer15Veto && type <= kSummer15Fake) {
-    double deltaEtaCut, deltaPhiCut, sigmaIetaIetaCut, hOverECut, ooEmooPCut;
-    bool isEB = ele->SCluster()->AbsEta() < gkEleEBEtaMax;
+  double deltaEtaCut, deltaPhiCut, sigmaIetaIetaCut, hOverECut, ooEmooPCut;
+  bool isEB = ele->SCluster()->AbsEta() < gkEleEBEtaMax;
 
-    switch (type) {
-    case kSummer15Veto:
-      deltaEtaCut      = isEB ? 0.0152 : 0.0113;
-      deltaPhiCut      = isEB ? 0.2160 : 0.2370;
-      sigmaIetaIetaCut = isEB ? 0.0114 : 0.0352;
-      hOverECut        = isEB ? 0.1810 : 0.1160;
-      ooEmooPCut       = isEB ? 0.2070 : 0.1740;
-      break;
-    case kSummer15Loose:
-      deltaEtaCut      = isEB ? 0.0105 : 0.00814;
-      deltaPhiCut      = isEB ? 0.1150 : 0.18200;
-      sigmaIetaIetaCut = isEB ? 0.0103 : 0.03010;
-      hOverECut        = isEB ? 0.1040 : 0.08970;
-      ooEmooPCut       = isEB ? 0.1020 : 0.12600;
-      break;
-    case kSummer15Fake:
-    case kSummer15Medium:
-      deltaEtaCut      = isEB ? 0.0103 : 0.00733;
-      deltaPhiCut      = isEB ? 0.0336 : 0.11400;
-      sigmaIetaIetaCut = isEB ? 0.0101 : 0.02830;
-      hOverECut        = isEB ? 0.0876 : 0.06780;
-      ooEmooPCut       = isEB ? 0.0174 : 0.08980;
-      break;
-    case kSummer15Tight:
-      deltaEtaCut      = isEB ? 0.00926 : 0.00724;
-      deltaPhiCut      = isEB ? 0.03360 : 0.09180;
-      sigmaIetaIetaCut = isEB ? 0.01010 : 0.02790;
-      hOverECut        = isEB ? 0.05970 : 0.06150;
-      ooEmooPCut       = isEB ? 0.01200 : 0.00999;
-      break;
-    case kSummer15Veto50ns:
-      deltaEtaCut      = isEB ? 0.0126 : 0.0109;
-      deltaPhiCut      = isEB ? 0.1070 : 0.2190;
-      sigmaIetaIetaCut = isEB ? 0.0120 : 0.0339;
-      hOverECut        = isEB ? 0.1860 : 0.0962;
-      ooEmooPCut       = isEB ? 0.2390 : 0.1410;
-      break;
-    case kSummer15Loose50ns:
-      deltaEtaCut      = isEB ? 0.00976 : 0.00952;
-      deltaPhiCut      = isEB ? 0.09290 : 0.18100;
-      sigmaIetaIetaCut = isEB ? 0.01050 : 0.03180;
-      hOverECut        = isEB ? 0.07650 : 0.08240;
-      ooEmooPCut       = isEB ? 0.18400 : 0.12500;
-      break;
-    case kSummer15Fake50ns:
-    case kSummer15Medium50ns:
-      deltaEtaCut      = isEB ? 0.0094 : 0.00733;
-      deltaPhiCut      = isEB ? 0.0296 : 0.14800;
-      sigmaIetaIetaCut = isEB ? 0.0101 : 0.02870;
-      hOverECut        = isEB ? 0.0372 : 0.05460;
-      ooEmooPCut       = isEB ? 0.1180 : 0.10400;
-      break;
-    case kSummer15Tight50ns:
-      deltaEtaCut      = isEB ? 0.00950 : 0.00762;
-      deltaPhiCut      = isEB ? 0.02910 : 0.04390;
-      sigmaIetaIetaCut = isEB ? 0.01010 : 0.02870;
-      hOverECut        = isEB ? 0.03720 : 0.05440;
-      ooEmooPCut       = isEB ? 0.01740 : 0.01000;
-      break;
-    default:
-      break;
-    };
+  switch (type) {
+  case kSummer15Veto:
+    deltaEtaCut      = isEB ? 0.0152 : 0.0113;
+    deltaPhiCut      = isEB ? 0.2160 : 0.2370;
+    sigmaIetaIetaCut = isEB ? 0.0114 : 0.0352;
+    hOverECut        = isEB ? 0.1810 : 0.1160;
+    ooEmooPCut       = isEB ? 0.2070 : 0.1740;
+    break;
+  case kSummer15Loose:
+    deltaEtaCut      = isEB ? 0.0105 : 0.00814;
+    deltaPhiCut      = isEB ? 0.1150 : 0.18200;
+    sigmaIetaIetaCut = isEB ? 0.0103 : 0.03010;
+    hOverECut        = isEB ? 0.1040 : 0.08970;
+    ooEmooPCut       = isEB ? 0.1020 : 0.12600;
+    break;
+  case kSummer15Fake:
+  case kSummer15Fake50ns:
+    deltaEtaCut      = isEB ? 0.0103 : 0.01000;
+    deltaPhiCut      = isEB ? 0.0400 : 0.11400;
+    sigmaIetaIetaCut = isEB ? 0.0110 : 0.03100;
+    hOverECut	     = isEB ? 0.0876 : 0.08000;
+    ooEmooPCut       = isEB ? 0.0174 : 0.08980;
+    break;
+  case kSummer15Medium:
+    deltaEtaCut      = isEB ? 0.0103 : 0.00733;
+    deltaPhiCut      = isEB ? 0.0336 : 0.11400;
+    sigmaIetaIetaCut = isEB ? 0.0101 : 0.02830;
+    hOverECut        = isEB ? 0.0876 : 0.06780;
+    ooEmooPCut       = isEB ? 0.0174 : 0.08980;
+    break;
+  case kSummer15Tight:
+    deltaEtaCut      = isEB ? 0.00926 : 0.00724;
+    deltaPhiCut      = isEB ? 0.03360 : 0.09180;
+    sigmaIetaIetaCut = isEB ? 0.01010 : 0.02790;
+    hOverECut        = isEB ? 0.05970 : 0.06150;
+    ooEmooPCut       = isEB ? 0.01200 : 0.00999;
+    break;
+  case kSummer15Veto50ns:
+    deltaEtaCut      = isEB ? 0.0126 : 0.0109;
+    deltaPhiCut      = isEB ? 0.1070 : 0.2190;
+    sigmaIetaIetaCut = isEB ? 0.0120 : 0.0339;
+    hOverECut        = isEB ? 0.1860 : 0.0962;
+    ooEmooPCut       = isEB ? 0.2390 : 0.1410;
+    break;
+  case kSummer15Loose50ns:
+    deltaEtaCut      = isEB ? 0.00976 : 0.00952;
+    deltaPhiCut      = isEB ? 0.09290 : 0.18100;
+    sigmaIetaIetaCut = isEB ? 0.01050 : 0.03180;
+    hOverECut        = isEB ? 0.07650 : 0.08240;
+    ooEmooPCut       = isEB ? 0.18400 : 0.12500;
+    break;
+  case kSummer15Medium50ns:
+    deltaEtaCut      = isEB ? 0.0094 : 0.00733;
+    deltaPhiCut      = isEB ? 0.0296 : 0.14800;
+    sigmaIetaIetaCut = isEB ? 0.0101 : 0.02870;
+    hOverECut        = isEB ? 0.0372 : 0.05460;
+    ooEmooPCut       = isEB ? 0.1180 : 0.10400;
+    break;
+  case kSummer15Tight50ns:
+    deltaEtaCut      = isEB ? 0.00950 : 0.00762;
+    deltaPhiCut      = isEB ? 0.02910 : 0.04390;
+    sigmaIetaIetaCut = isEB ? 0.01010 : 0.02870;
+    hOverECut        = isEB ? 0.03720 : 0.05440;
+    ooEmooPCut       = isEB ? 0.01740 : 0.01000;
+    break;
+  default:
+    return false;
+  };
 
-    if (std::abs(ele->DeltaEtaSuperClusterTrackAtVtx()) > deltaEtaCut)
-      return false;
-    if (std::abs(ele->DeltaPhiSuperClusterTrackAtVtx()) > deltaPhiCut)
-      return false;
-    if (ele->CoviEtaiEta5x5() > sigmaIetaIetaCut)
-      return false;
-    if (ele->HadOverEmTow() > hOverECut)
-      return false;
-    if (std::abs(1. / ele->SCluster()->Energy() - 1. / ele->GsfTrk()->P()) > ooEmooPCut)
-      return false;
+  if (std::abs(ele->DeltaEtaSuperClusterTrackAtVtx()) > deltaEtaCut)
+    return false;
+  if (std::abs(ele->DeltaPhiSuperClusterTrackAtVtx()) > deltaPhiCut)
+    return false;
+  double sigmaIetaIeta = ele->CoviEtaiEta5x5();
+  if (sigmaIetaIeta < 0.) // backward compatibility
+    sigmaIetaIeta = ele->CoviEtaiEta();
+  if (sigmaIetaIeta > sigmaIetaIetaCut)
+    return false;
+  if (ele->HadOverEmTow() > hOverECut)
+    return false;
+  if (std::abs(1. / ele->SCluster()->Energy() - 1. / ele->GsfTrk()->P()) > ooEmooPCut)
+    return false;
 
-    return true;
-  }
-
-  return false;
+  return true;
 }
 
 Bool_t
@@ -439,22 +444,21 @@ mithep::ElectronTools::PassIso(Electron const* ele, EElIsoType isoType)
 
 Bool_t
 mithep::ElectronTools::PassPFIso(Electron const* ele, EElIsoType isoType,
-                                 PFCandidateCol const* pfCandidates, Vertex const* vertex,
+                                 PFCandidateCol const* pfCandidates/* = 0*/, Vertex const* vertex/* = 0*/,
                                  MuonCol const* nonisolatedMuons/* = 0*/, ElectronCol const* nonisolatedElectrons/* = 0*/)
 {
-  double cutvalue;
-
-  if (ele->SCluster()->AbsEta() < gkEleEBEtaMax)
-    cutvalue = 0.13 * ele->Pt();
-  else
-    cutvalue = 0.09 * ele->Pt();
+  bool isEB = ele->SCluster()->AbsEta() < gkEleEBEtaMax;
 
   switch (isoType) {
   case kPFIso:
-    return IsolationTools::PFElectronIsolation(ele, pfCandidates, vertex, 0.1, 1.0, 0.4, 0.3) * ele->Pt() < cutvalue;
+    return IsolationTools::PFElectronIsolation(ele, pfCandidates, vertex, 0.1, 1.0, 0.4, 0.3) < (isEB ? 0.13 : 0.09);
 
   case kPFIsoNoL:
-    return IsolationTools::PFElectronIsolation(ele, pfCandidates, nonisolatedMuons, nonisolatedElectrons, vertex, 0.1, 1.0, 0.4, 0.3) < cutvalue;
+    return IsolationTools::PFElectronIsolation(ele, pfCandidates, nonisolatedMuons, nonisolatedElectrons, vertex, 0.1, 1.0, 0.4, 0.3) / ele->Pt() < (isEB ? 0.13 : 0.09);
+
+  case kSummer15FakeIso:
+  case kSummer15Fake50nsIso:
+    return ele->PFPhotonIso() / ele->Pt() < 0.45 && ele->PFNeutralHadronIso() / ele->Pt() < 0.25 && ele->PFChargedHadronIso() / ele->Pt() < 0.2;
 
   default:
     return false;
@@ -477,25 +481,42 @@ mithep::ElectronTools::PassIsoRhoCorr(Electron const* ele, EElIsoType isoType, D
     //fallthrough
   case kPFIso_HggLeptonTag2012HCP:
     return IsolationTools::PFElectronIsolation2012LepTag(ele, vertex, pfCandidates, rho, kEleEAData2012, 0, 0, 0.3) < 0.15;
+  default:
+    return false;
+  }
+}
 
+Bool_t
+mithep::ElectronTools::PassIsoFootprintRhoCorr(Electron const* ele, EElIsoType isoType, Double_t rho,
+                                               PFCandidateCol const* pfCandidates, Vertex const* vertex)
+{
+  double scEta = ele->SCluster()->Eta();
+  bool isEB = std::abs(scEta) < gkEleEBEtaMax;
+
+  double chIso = 0.;
+  double nhIso = 0.;
+  double phIso = 0.;
+  IsolationTools::PFEGIsoFootprintRemoved(ele, vertex, pfCandidates, 0.3, chIso, nhIso, phIso);
+
+  double combRelIso = IsolationTools::PFEleCombinedIsolationRhoCorr(chIso, nhIso + phIso, rho, scEta, kEleEASummer15) / ele->Pt();
+
+  switch (isoType) {
   case kSummer15VetoIso:
+    return combRelIso < (isEB ? 0.1260 : 0.1440);
   case kSummer15LooseIso:
+    return combRelIso < (isEB ? 0.0893 : 0.1210);
   case kSummer15MediumIso:
+    return combRelIso < (isEB ? 0.0766 : 0.0678);
   case kSummer15TightIso:
-  case kSummer15FakeIso:
-    {
-      double relIso = IsolationTools::PFElectronIsolationRhoCorr(ele, rho, kEleEASummer15) / ele->Pt();
-      if (isoType == kSummer15VetoIso)
-        return relIso < (isEB ? 0.1260 : 0.1440);
-      else if (isoType == kSummer15LooseIso)
-        return relIso < (isEB ? 0.0893 : 0.1210);
-      else if (isoType == kSummer15MediumIso)
-        return relIso < (isEB ? 0.0766 : 0.0678);
-      else if (isoType == kSummer15FakeIso)
-        return relIso < (isEB ? 0.3500 : 0.3500);
-      else
-        return relIso < (isEB ? 0.0354 : 0.0646);
-    }
+    return combRelIso < (isEB ? 0.0354 : 0.0646);
+  case kSummer15Veto50nsIso:
+    return combRelIso < (isEB ? 0.161 : 0.193);
+  case kSummer15Loose50nsIso:
+    return combRelIso < (isEB ? 0.118 : 0.118);
+  case kSummer15Medium50nsIso:
+    return combRelIso < (isEB ? 0.0987 : 0.0902);
+  case kSummer15Tight50nsIso:
+    return combRelIso < (isEB ? 0.0591 : 0.0759);
   default:
     return false;
   }

--- a/Utils/src/IsolationTools.cc
+++ b/Utils/src/IsolationTools.cc
@@ -649,14 +649,21 @@ Double_t IsolationTools::PFElectronIsolation2012LepTag(const Electron *ele, cons
 }
 
 Double_t
-mithep::IsolationTools::PFElectronIsolationRhoCorr(mithep::Electron const* ele, Double_t rho, ElectronTools::EElectronEffectiveAreaTarget eaDef)
+mithep::IsolationTools::PFEleCombinedIsolationRhoCorr(mithep::Electron const* ele, Double_t rho, ElectronTools::EElectronEffectiveAreaTarget eaDef)
 {
-  double eta = ele->SCluster()->Eta();
+  return PFEleCombinedIsolationRhoCorr(ele->PFChargedHadronIso(),
+                                       ele->PFNeutralHadronIso() + ele->PFPhotonIso(),
+                                       rho, ele->SCluster()->Eta(), eaDef);
+}
+
+Double_t
+mithep::IsolationTools::PFEleCombinedIsolationRhoCorr(Double_t chargedIso, Double_t neutralIso, Double_t rho, Double_t eta, ElectronTools::EElectronEffectiveAreaTarget eaDef)
+{
   double effArea = ElectronTools::ElectronEffectiveArea(ElectronTools::kEleNeutralIso03, eta, ElectronTools::kEleEASummer15);
 
-  double isolation = ele->PFNeutralHadronIso() + ele->PFPhotonIso() - effArea * rho;
+  double isolation = neutralIso - effArea * rho;
   if (isolation < 0.) isolation = 0.;
-  isolation += ele->PFChargedHadronIso();
+  isolation += chargedIso;
 
   // this function is expected to return the absolute iso
   return isolation;
@@ -1398,7 +1405,7 @@ Double_t IsolationTools::PFNeutralHadronIsolation(const Photon *p, Double_t extR
 
 void
 IsolationTools::PFEGIsoFootprintRemoved(Particle const* part, Vertex const* pv, PFCandidateCol const* pfCands, Double_t dR,
-                                            Double_t& chIso, Double_t& nhIso, Double_t& phIso)
+                                        Double_t& chIso, Double_t& nhIso, Double_t& phIso)
 {
   SuperCluster const* sc = 0;
   std::function<bool(PFCandidate const&)> inFootprint;

--- a/Utils/src/PhotonTools.cc
+++ b/Utils/src/PhotonTools.cc
@@ -57,45 +57,41 @@ mithep::PhotonTools::PhotonEffectiveArea(EPhotonEffectiveAreaType type, Double_t
 Bool_t
 mithep::PhotonTools::PassID(Photon const* pho, EPhIdType type)
 {
-  if (type == kSummer15Tight || type == kSummer15Medium || type == kSummer15Loose) {
-    double hOverECut, sigmaIEtaIEtaCut;
-    bool isEB = pho->SCluster()->AbsEta() < gkPhoEBEtaMax;
+  double hOverECut, sigmaIEtaIEtaCut;
+  bool isEB = pho->SCluster()->AbsEta() < gkPhoEBEtaMax;
 
-    switch (type) {
-    case kSummer15Loose:
-      hOverECut        = isEB ? 0.028  : 0.093;
-      sigmaIEtaIEtaCut = isEB ? 0.0107 : 0.0272;
-      break;
-    case kSummer15Medium:
-      hOverECut        = isEB ? 0.012  : 0.023;
-      sigmaIEtaIEtaCut = isEB ? 0.0100 : 0.0267;
-      break;
-    case kSummer15Tight:
-      hOverECut        = isEB ? 0.010  : 0.015;
-      sigmaIEtaIEtaCut = isEB ? 0.0100 : 0.0265;
-      break;
-    default:
-      break;
-    }
-
-    if (pho->HadOverEm() > hOverECut)
-      return false;
-
-    //This is for backwards compatibility
-    double ietaieta = -1;
-    if (pho->CoviEtaiEta5x5() < 0) 
-      ietaieta = pho->CoviEtaiEta();
-    else 
-      ietaieta = pho->CoviEtaiEta5x5();
-
-    //check the cut
-    if (ietaieta > sigmaIEtaIEtaCut)
-      return false;
-
-    return true;
+  switch (type) {
+  case kSummer15Loose:
+    hOverECut        = isEB ? 0.028  : 0.093;
+    sigmaIEtaIEtaCut = isEB ? 0.0107 : 0.0272;
+    break;
+  case kSummer15Medium:
+    hOverECut        = isEB ? 0.012  : 0.023;
+    sigmaIEtaIEtaCut = isEB ? 0.0100 : 0.0267;
+    break;
+  case kSummer15Tight:
+    hOverECut        = isEB ? 0.010  : 0.015;
+    sigmaIEtaIEtaCut = isEB ? 0.0100 : 0.0265;
+    break;
+  default:
+    return false;
   }
 
-  return false;
+  if (pho->HadOverEmTow() > hOverECut)
+    return false;
+
+  //This is for backwards compatibility
+  double ietaieta = -1;
+  if (pho->CoviEtaiEta5x5() < 0) 
+    ietaieta = pho->CoviEtaiEta();
+  else 
+    ietaieta = pho->CoviEtaiEta5x5();
+
+  //check the cut
+  if (ietaieta > sigmaIEtaIEtaCut)
+    return false;
+
+  return true;
 }
 
 Bool_t
@@ -123,16 +119,6 @@ mithep::PhotonTools::PassIsoRhoCorr(Photon const* pho, EPhIsoType isoType, Doubl
   bool isEB = scEta < gkPhoEBEtaMax;
   double pEt = pho->Et();
 
-  double chIsoCor = 0.;
-  double nhIsoCor = 0.;
-  double phIsoCor = 0.;
-
-  if (isoType == kSummer15TightIso || isoType == kSummer15MediumIso || isoType == kSummer15LooseIso) {
-    chIsoCor = IsolationTools::PFPhotonIsolationRhoCorr(scEta, chIso, rho, kPhoEAPhys14, kPhoChargedHadron03);
-    nhIsoCor = IsolationTools::PFPhotonIsolationRhoCorr(scEta, nhIso, rho, kPhoEAPhys14, kPhoNeutralHadron03);
-    phIsoCor = IsolationTools::PFPhotonIsolationRhoCorr(scEta, phIso, rho, kPhoEAPhys14, kPhoPhoton03);
-  }
-
   double chIsoCut = 0.;
   double nhIsoCut = 0.;
   double phIsoCut = 0.;
@@ -154,14 +140,14 @@ mithep::PhotonTools::PassIsoRhoCorr(Photon const* pho, EPhIsoType isoType, Doubl
     phIsoCut = isEB ? (1.40 + 0.0014 * pEt) : (1.40 + 0.0091 * pEt);
     break;
   default:
-    break;
+    return false;
   }
 
-  if (chIsoCor > chIsoCut)
+  if (IsolationTools::PFPhotonIsolationRhoCorr(scEta, chIso, rho, kPhoEAPhys14, kPhoChargedHadron03) > chIsoCut)
     return false;
-  if (nhIsoCor > nhIsoCut)
+  if (IsolationTools::PFPhotonIsolationRhoCorr(scEta, nhIso, rho, kPhoEAPhys14, kPhoNeutralHadron03) > nhIsoCut)
     return false;
-  if (phIsoCor > phIsoCut)
+  if (IsolationTools::PFPhotonIsolationRhoCorr(scEta, phIso, rho, kPhoEAPhys14, kPhoPhoton03) > phIsoCut)
     return false;
 
   return true;


### PR DESCRIPTION
- Photon id was using the "old" H/E definition. Now fixed to use single-tower.
- Electron id: Added Guillelmo's fakeable object definition and 50ns isolation cuts. Fixed a bug that was killing all 50ns ids.
