### PR TITLE
Muonid fix

### DIFF
--- a/Mods/src/MuonIDModRun1.cc
+++ b/Mods/src/MuonIDModRun1.cc
@@ -267,13 +267,6 @@ void MuonIDModRun1::Process()
 	mu->Quality().Quality(MuonQuality::GlobalMuonPromptTight);
       break;
     case MuonTools::kTight:
-      idpass = mu->BestTrk() != 0 &&
-	mu->NTrkLayersHit() > 5 &&
-	mu->IsPFMuon() == kTRUE &&
-	mu->BestTrk()->NPixelHits() > 0 &&
-	RChi2 < 10.0;
-      break;
-    case MuonTools::kMuonPOG2012CutBasedIdTight:
       idpass = mu->IsGlobalMuon() &&
 	mu->IsPFMuon() &&
 	mu->GlobalTrk()->RChi2() < 10 &&
@@ -619,8 +612,6 @@ void MuonIDModRun1::SlaveBegin()
     fMuIDType = MuonTools::kZMuId;
   else if (fMuonIDType.CompareTo("Tight") == 0)
     fMuIDType = MuonTools::kTight;
-  else if (fMuonIDType.CompareTo("muonPOG2012CutBasedIDTight") == 0)
-    fMuIDType = MuonTools::kMuonPOG2012CutBasedIdTight;
   else if (fMuonIDType.CompareTo("Loose") == 0)
     fMuIDType = MuonTools::kLoose;
   else if (fMuonIDType.CompareTo("WWMuIdV1") == 0)

--- a/Mods/src/PhotonIdMod.cc
+++ b/Mods/src/PhotonIdMod.cc
@@ -85,6 +85,9 @@ mithep::PhotonIdMod::PassIdCut(Photon const& pho)
   case PhotonTools::kSummer15Loose:
     return PhotonTools::PassID(&pho, PhotonTools::EPhIdType(fIdType));
 
+  case PhotonTools::kNoId:
+    return true;
+
   default:
     return false;
   }

--- a/Utils/interface/MuonTools.h
+++ b/Utils/interface/MuonTools.h
@@ -35,8 +35,9 @@ namespace mithep {
         kZMuId,             //"ZMuId"
         kTight,             //"Tight"
         kMedium,             //"Medium"
-        kMuonPOG2012CutBasedIdTight,             //"muonPOG2012CutBasedIDTight"
         kLoose,             //"Loose"
+        kTightIP,           // Tight with tighter IP cut than POG recommendation
+        kLooseIP,           // Loose with an IP cut
         kWWMuIdV1,          //"WWMuIdV1"
         kWWMuIdV2,          //"WWMuIdV2"
         kWWMuIdV3,          //"WWMuIdV3"
@@ -157,9 +158,9 @@ namespace mithep {
       static Double_t GetSegmentCompatibility(const mithep::Muon *iMuon);
       static Bool_t   PassD0Cut(const Muon *mu, const VertexCol *vertices, EMuIdType, Int_t iVertex = 0);
       static Bool_t   PassD0Cut(const Muon *mu, const BeamSpotCol *beamspots, EMuIdType);
-      static Bool_t   PassD0Cut(const Muon *mu, Double_t d0, EMuIdType);
+      static Bool_t   PassD0Cut(Double_t d0, EMuIdType);
       static Bool_t   PassDZCut(const Muon *mu, const VertexCol *vertices, EMuIdType, Int_t iVertex = 0);
-      static Bool_t   PassDZCut(const Muon *mu, Double_t dz, EMuIdType);
+      static Bool_t   PassDZCut(Double_t dz, EMuIdType);
       static Bool_t   PassSoftMuonCut(const Muon *mu, const VertexCol *vertices, const Bool_t applyIso = kTRUE);
       static Double_t MuonEffectiveArea(EMuonEffectiveAreaType type, Double_t Eta, 
                                         EMuonEffectiveAreaTarget EffectiveAreaTarget = kMuEAData2011);

--- a/Utils/interface/PhotonTools.h
+++ b/Utils/interface/PhotonTools.h
@@ -36,6 +36,7 @@ namespace mithep {
 
     enum EPhIdType {
       kIdUndef = 0,       //not defined
+      kNoId,
       kTight,             //"Tight"
       kLoose,             //"Loose"
       kLooseEM,           //"LooseEM"


### PR DESCRIPTION
Removing muon "2012POG tight" id because it turns out to be identical to kTight.
Impact parameter cuts for kTight (d0<2mm, dz<5mm) and kLoose (none) brought back to POG definitions. Added kTightIP (d0<0.2mm, dz<1mm) and kLooseIP (d0<2mm, dz<5mm).
