### PR TITLE
turning off charge filter in default setting

### DIFF
--- a/Mods/interface/ElectronIdMod.h
+++ b/Mods/interface/ElectronIdMod.h
@@ -93,12 +93,12 @@ namespace mithep {
     Bool_t   fApplySpikeRemoval = kFALSE;      //whether spike removal - uses SC seed which can be absent in ged electrons
     Bool_t   fApplyD0Cut = kTRUE;             //whether apply d0 cut
     Bool_t   fApplyDZCut = kTRUE;             //whether apply dz cut
-    Bool_t   fChargeFilter = kTRUE;           //whether apply GSF and CFT equal requirement
+    Bool_t   fChargeFilter = kFALSE;           //whether apply GSF and CFT equal requirement
     Bool_t   fApplyTriggerMatching = kFALSE;   //match to hlt electron (default=0)
     Bool_t   fApplyEcalSeeded = kFALSE;        //require ecal seeded flag
     Bool_t   fApplyEcalFiducial = kFALSE;      //apply ecal fiducial cuts on supercluster eta
     UInt_t   fRhoAlgo = mithep::PileupEnergyDensity::kFixedGridFastjetAll;
-    Int_t    fWhichVertex = -1;            //vertex to use (-2: beamspot, -1: closest in Z)
+    Int_t    fWhichVertex = 0;            //vertex to use (-2: beamspot, -1: closest in Z)
     Double_t fElectronEtMin = 0.;          //min pt cut
     Double_t fIdLikelihoodCut = -999.;        //cut value for Id likelihood
 

--- a/Mods/python/ElectronIdMod.py
+++ b/Mods/python/ElectronIdMod.py
@@ -13,5 +13,13 @@ electronIdMod = mithep.ElectronIdMod(
     ApplyConvFilterType1 = False,
     ApplyConvFilterType2 = False,
     ApplyNExpectedHitsInnerCut = False,
+    InvertNExpectedHitsInnerCut = False,
+    ApplySpikeRemoval = False,
+    ChargeFilter = False,
+    ApplyTriggerMatching = False,
+    ApplyEcalSeeded = False,
+    RhoAlgo = mithep.PileupEnergyDensity.kFixedGridFastjetAll,
+    EtMin = 0.,
+    IdLikelihoodCut = -999.,
     ConversionsName = 'Conversions'
 )


### PR DESCRIPTION
Turning off charge filter from electron id default configuration.
Also, we should align the python default settings to correspond to what's in the .h files. Starting with electron id..
