### PR TITLE
changed fake muon iso slightly + name consistency

### DIFF
--- a/Mods/src/MuonIDModRun1.cc
+++ b/Mods/src/MuonIDModRun1.cc
@@ -124,7 +124,7 @@ void MuonIDModRun1::Process()
   }
   if (fMuIsoType == MuonTools::kPFRadialIso ||
       fMuIsoType == MuonTools::kIsoDeltaR   ||
-      fMuIsoType == MuonTools::kPFIsoBetaPUCorrected) {
+      fMuIsoType == MuonTools::kPFIsoBetaPUCorrectedTight) {
     fPFNoPileUpCands = GetObject<PFCandidateCol>(fPFNoPileUpName);
     fPFPileUpCands   = GetObject<PFCandidateCol>(fPFPileUpName);
   }
@@ -443,7 +443,7 @@ void MuonIDModRun1::Process()
           isocut = kTRUE;
       }
       break;
-    case MuonTools::kPFIsoBetaPUCorrected:
+    case MuonTools::kPFIsoBetaPUCorrectedTight:
       {
         Double_t pfIsoCutValue = 9999;
         if (fPFIsolationCut > 0) {
@@ -652,8 +652,8 @@ void MuonIDModRun1::SlaveBegin()
     fMuIsoType = MuonTools::kPFIso;
   else if (fMuonIsoType.CompareTo("PFRadialIso") == 0)
     fMuIsoType = MuonTools::kPFRadialIso;
-  else if (fMuonIsoType.CompareTo("PFIsoBetaPUCorrected") == 0)
-    fMuIsoType = MuonTools::kPFIsoBetaPUCorrected;
+  else if (fMuonIsoType.CompareTo("PFIsoBetaPUCorrectedTight") == 0)
+    fMuIsoType = MuonTools::kPFIsoBetaPUCorrectedTight;
   else if (fMuonIsoType.CompareTo("PFIsoEffectiveAreaCorrected") == 0)
     fMuIsoType = MuonTools::kPFIsoEffectiveAreaCorrected;
   else if (fMuonIsoType.CompareTo("PFIsoNoL") == 0)

--- a/Mods/src/MuonIdMod.cc
+++ b/Mods/src/MuonIdMod.cc
@@ -111,7 +111,7 @@ mithep::MuonIdMod::PassIsolation(mithep::Muon const& muon)
   case MuonTools::kPFRadialIso:
     return MuonTools::PassPFIso(&muon, MuonTools::kPFRadialIso, GetPFNoPileupCandidates());
 
-  case MuonTools::kPFIsoBetaPUCorrected:
+  case MuonTools::kPFIsoBetaPUCorrectedFake:
   case MuonTools::kPFIsoBetaPUCorrectedLoose:
   case MuonTools::kPFIsoBetaPUCorrectedTight:
     return MuonTools::PassPFIso(&muon, MuonTools::EMuIsoType(fIsoType), GetPFNoPileupCandidates(), 0, GetPFPileupCandidates());

--- a/Utils/interface/MuonTools.h
+++ b/Utils/interface/MuonTools.h
@@ -58,9 +58,9 @@ namespace mithep {
         kCustomIso,                         //"Custom"
         kPFIso,                             //"PFIso"
         kPFRadialIso,                       //"PFRadialIso"
-        kPFIsoBetaPUCorrected,              //"PFISo with PUcorrection using delta Beta, super loose cut (0.4)
-        kPFIsoBetaPUCorrectedLoose,         //"PFISo with PUcorrection using delta Beta, loose cut (0.2)
-        kPFIsoBetaPUCorrectedTight,         //"PFISo with PUcorrection using delta Beta, tight cut (0.12)
+        kPFIsoBetaPUCorrectedFake,          //"PFISo with PUcorrection using delta Beta, super loose cut (0.4)+trackerIso cut"
+        kPFIsoBetaPUCorrectedLoose,         //"PFISo with PUcorrection using delta Beta, loose cut (0.2)"
+        kPFIsoBetaPUCorrectedTight,         //"PFISo with PUcorrection using delta Beta, tight cut (0.12)"
         kPFIsoEffectiveAreaCorrected,       //"PFIso with EffectiveArea Pileup Correction"
         kPFIsoNoL,                          //"PFIsoNoL"
         kNoIso,                             //"NoIso"

--- a/Utils/src/MuonTools.cc
+++ b/Utils/src/MuonTools.cc
@@ -616,9 +616,9 @@ mithep::MuonTools::PassPFIso(Muon const* mu, EMuIsoType type, PFCandidateCol con
       return IsolationTools::PFRadialMuonIsolation(mu, pfCandidates, 1.0, 0.3) < mu->Pt() * cutValue;
     }
 
-  case kPFIsoBetaPUCorrected:
+  case kPFIsoBetaPUCorrectedFake:
     // pfCandidates here should be NoPileupCandidates
-    return IsolationTools::BetaMwithPUCorrection(pfCandidates, pileupCands, mu, 0.4) < mu->Pt() * 0.4;
+    return (mu->IsoR03SumPt() < mu->Pt() * 0.4 && IsolationTools::BetaMwithPUCorrection(pfCandidates, pileupCands, mu, 0.4) < mu->Pt() * 0.4);
 
   case kPFIsoBetaPUCorrectedLoose:
     // pfCandidates here should be NoPileupCandidates

--- a/macros/examples/runHgg2013Final_7TeV.C
+++ b/macros/examples/runHgg2013Final_7TeV.C
@@ -281,7 +281,7 @@ void runHgg2013Final_7TeV(const char *fileset    = "0000",
   muonIdMod -> SetWhichVertex(-1); // this is a 'hack'.. but hopefully good enough...
   muonIdMod -> SetD0Cut(0.2);
   muonIdMod -> SetDZCut(0.5);
-  muonIdMod -> SetIsoType("PFIsoBetaPUCorrected"); //h
+  muonIdMod -> SetIsoType("PFIsoBetaPUCorrectedTight"); //h
   muonIdMod -> SetPFIsoCut(0.2); //h
   muonIdMod -> SetOutputName("HggLeptonTagMuons");
   muonIdMod -> SetPFNoPileUpName("pfnopileupcands");
@@ -298,7 +298,7 @@ void runHgg2013Final_7TeV(const char *fileset    = "0000",
   softMuonIdMod -> SetWhichVertex(-1); // this is a 'hack'.. but hopefully good enough...
   softMuonIdMod -> SetD0Cut(0.2);
   softMuonIdMod -> SetDZCut(0.5);
-  softMuonIdMod -> SetIsoType("PFIsoBetaPUCorrected"); //h
+  softMuonIdMod -> SetIsoType("PFIsoBetaPUCorrectedTight"); //h
   softMuonIdMod -> SetPFIsoCut(0.2); //h
   softMuonIdMod -> SetOutputName("HggLeptonTagSoftMuons");
   softMuonIdMod -> SetPFNoPileUpName("pfnopileupcands");

--- a/macros/examples/runHgg2013Final_8TeV.C
+++ b/macros/examples/runHgg2013Final_8TeV.C
@@ -324,7 +324,7 @@ void runHgg2013Final_8TeV(const char *fileset    = "0000",
   muonIdMod -> SetWhichVertex(-1); // this is a 'hack'.. but hopefully good enough...
   muonIdMod -> SetD0Cut(0.2);
   muonIdMod -> SetDZCut(0.5);
-  muonIdMod -> SetIsoType("PFIsoBetaPUCorrected"); //h
+  muonIdMod -> SetIsoType("PFIsoBetaPUCorrectedTight"); //h
   muonIdMod -> SetPFIsoCut(0.2); //h
   muonIdMod -> SetOutputName("HggLeptonTagMuons");
   muonIdMod -> SetPFNoPileUpName("pfnopileupcands");
@@ -341,7 +341,7 @@ void runHgg2013Final_8TeV(const char *fileset    = "0000",
   softMuonIdMod -> SetWhichVertex(-1); // this is a 'hack'.. but hopefully good enough...
   softMuonIdMod -> SetD0Cut(0.2);
   softMuonIdMod -> SetDZCut(0.5);
-  softMuonIdMod -> SetIsoType("PFIsoBetaPUCorrected"); //h
+  softMuonIdMod -> SetIsoType("PFIsoBetaPUCorrectedTight"); //h
   softMuonIdMod -> SetPFIsoCut(0.2); //h
   softMuonIdMod -> SetOutputName("HggLeptonTagSoftMuons");
   softMuonIdMod -> SetPFNoPileUpName("pfnopileupcands");

--- a/macros/examples/runHgg2013Final_8TeV_test.C
+++ b/macros/examples/runHgg2013Final_8TeV_test.C
@@ -291,7 +291,7 @@ void runHgg2013Final_8TeV_test(const char *fileset    = "0000",
   muonIdMod -> SetWhichVertex(-1); // this is a 'hack'.. but hopefully good enough...
   muonIdMod -> SetD0Cut(0.2);
   muonIdMod -> SetDZCut(0.5);
-  muonIdMod -> SetIsoType("PFIsoBetaPUCorrected"); //h
+  muonIdMod -> SetIsoType("PFIsoBetaPUCorrectedTight"); //h
   muonIdMod -> SetPFIsoCut(0.2); //h
   muonIdMod -> SetOutputName("HggLeptonTagMuons");
   muonIdMod -> SetPFNoPileUpName("pfnopileupcands");

--- a/macros/examples/runHgg2013Moriond.C
+++ b/macros/examples/runHgg2013Moriond.C
@@ -285,7 +285,7 @@ void runHgg2013Moriond(const char *fileset    = "0000",
   muonIdMod -> SetWhichVertex(-1); // this is a 'hack'.. but hopefully good enough...
   muonIdMod -> SetD0Cut(0.2);
   muonIdMod -> SetDZCut(0.5);
-  muonIdMod -> SetIsoType("PFIsoBetaPUCorrected"); //h
+  muonIdMod -> SetIsoType("PFIsoBetaPUCorrectedTight"); //h
   muonIdMod -> SetPFIsoCut(0.2); //h
   muonIdMod -> SetOutputName("HggLeptonTagMuons");
   muonIdMod -> SetPFNoPileUpName("pfnopileupcands");


### PR DESCRIPTION
Delta-beta corrected PF iso for muons is now either Tight, Loose, or Fake in the order of diminishing tightness.
