### PR TITLE
Making MinJetPt configurable for type1 correction

### DIFF
--- a/Mods/interface/MetCorrectionMod.h
+++ b/Mods/interface/MetCorrectionMod.h
@@ -71,6 +71,7 @@ namespace mithep {
     void SetMaxEMFraction(Double_t m)          { fMaxEMFraction = m; }
     void SetSkipMuons(Bool_t s)                { fSkipMuons = s; }
     void SetMaxJetEta(Double_t m)              { fMaxJetEta = m; }
+    void SetMinJetPt(Double_t m)               { fMinJetPt = m; }
     // shift parameters
     void IsData(bool b)                        { fIsData = b; }
 
@@ -107,6 +108,7 @@ namespace mithep {
                                         //for jet to be in Type1 corr (< 0 -> does not skip jets)
     Bool_t        fSkipMuons = kFALSE; //remove muon P4 from jet P4 in Type 1 corr
     Double_t      fMaxJetEta = std::numeric_limits<double>::max();
+    Double_t      fMinJetPt = 15.;
                   
     Bool_t        fIsData = kTRUE; //flag for data/MC distinction
     Bool_t        fPrint = kFALSE; //flag for debug print out

--- a/Mods/python/MetCorrectionMod.py
+++ b/Mods/python/MetCorrectionMod.py
@@ -7,18 +7,10 @@ metCorrectionMod = mithep.MetCorrectionMod(
     JetsName = 'AKt4PFJets',
     RhoAlgo = mithep.PileupEnergyDensity.kFixedGridFastjetAll,
     MaxEMFraction = 0.9,
-    SkipMuons = True
+    SkipMuons = True,
+    MinJetPt = 15.
 )
 metCorrectionMod.ApplyType0(False)
 metCorrectionMod.ApplyType1(True)
 metCorrectionMod.ApplyShift(False)
 metCorrectionMod.IsData(analysis.isRealData)
-if analysis.isRealData:
-    metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/74X_dataRun2_Prompt_v1_L1FastJet_AK4PFchs.txt")
-    metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/74X_dataRun2_Prompt_v1_L2Relative_AK4PFchs.txt")
-    metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/74X_dataRun2_Prompt_v1_L3Absolute_AK4PFchs.txt")
-    metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/74X_dataRun2_Prompt_v1_L2L3Residual_AK4PFchs.txt")
-else:
-    metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L1FastJet_AK4PF.txt")
-    metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L2Relative_AK4PF.txt")
-    metCorrectionMod.AddJetCorrectionFromFile(os.environ['MIT_DATA'] + "/MCRUN2_74_V9_L3Absolute_AK4PF.txt")

--- a/Mods/src/MetCorrectionMod.cc
+++ b/Mods/src/MetCorrectionMod.cc
@@ -260,7 +260,7 @@ MetCorrectionMod::Process()
       auto fullCorrMom = inJetRawMom * fullCorr;
 
       // do not propagate JEC for soft jets
-      if (fullCorrMom.Pt() < 10.) continue;
+      if (fullCorrMom.Pt() < fMinJetPt) continue;
 
       auto offsetCorrMom = inJetRawMom * offsetCorr;
 


### PR DESCRIPTION
Recently JetMET updated the minimum jet pT threshold for the type-1 correction to 15 GeV.
