### PR TITLE
new implementation of BadEventsFilterMod (works with >= 043)

### DIFF
--- a/SelMods/interface/BadEventsFilterMod.h
+++ b/SelMods/interface/BadEventsFilterMod.h
@@ -20,42 +20,20 @@ namespace mithep {
     BadEventsFilterMod(char const* name = "BadEventsFilterMod", char const* title = "MET filters") : BaseMod(name, title) {}
     ~BadEventsFilterMod() {}
 
-    // Must be identical to MitProd/TreeFiller/interface/FillerEvtSelData
-    // -> One reason why the implementation is poor. At least this enum should be defined in MitAna/DataTree.
-    enum EvtSelFilter {
-      kHBHENoiseFilter,
-      kECALDeadCellFilter,
-      kTrackingFailureFilter,
-      kEEBadScFilter,
-      kECALaserCorrFilter,
-      kManyStripClusFilter,
-      kTooManyStripClusFilter,
-      kLogErrorTooManyClustersFilter,
-      kCSCTightHaloFilter,
-      kCSCLooseHaloFilter,
-      nEvtSelFilters
-    };
-
     void SetInputName(char const* n) { fEvtSelDataName = n; }
+    void SetLabelTreeName(char const* n) { fLabelTreeName = n; }
+    void SetLabelBranchName(char const* n) { fLabelBranchName = n; }
 
-    void SetHBHENoiseFilter(Bool_t b = kTRUE) { SetMask(kHBHENoiseFilter, b); }
-    void SetECALDeadCellFilter(Bool_t b = kTRUE) { SetMask(kECALDeadCellFilter, b); }
-    void SetTrackingFailureFilter(Bool_t b = kTRUE) { SetMask(kTrackingFailureFilter, b); }
-    void SetEEBadScFilter(Bool_t b = kTRUE) { SetMask(kEEBadScFilter, b); }
-    void SetECALaserCorrFilter(Bool_t b = kTRUE) { SetMask(kECALaserCorrFilter, b); }
-    void SetManyStripClusFilter(Bool_t b = kTRUE) { SetMask(kManyStripClusFilter, b); }
-    void SetTooManyStripClusFilter(Bool_t b = kTRUE) { SetMask(kTooManyStripClusFilter, b); }
-    void SetLogErrorTooManyClustersFilter(Bool_t b = kTRUE) { SetMask(kLogErrorTooManyClustersFilter, b); }
-    void SetCSCTightHaloFilter(Bool_t b = kTRUE) { SetMask(kCSCTightHaloFilter, b); }
-    void SetCSCLooseHaloFilter(Bool_t b = kTRUE) { SetMask(kCSCLooseHaloFilter, b); }
+    void SetFilter(char const* name, Bool_t enable = kTRUE);
 
   protected:
     void SlaveBegin() override;
     void Process() override;
 
-    void SetMask(EvtSelFilter, Bool_t);
-
     TString fEvtSelDataName{"EvtSelData"};
+    TString fLabelTreeName{"EvtSelBits"};
+    TString fLabelBranchName{"FilterLabels"};
+    std::vector<std::string> fEnabledFilters{};
     Int_t fBitMask{0};
 
     TH1D* hCounter{0};

--- a/SelMods/src/BadEventsFilterMod.cc
+++ b/SelMods/src/BadEventsFilterMod.cc
@@ -2,13 +2,57 @@
 
 #include "MitAna/DataTree/interface/EvtSelData.h"
 
+#include "TFile.h"
+
+#include <algorithm>
+
 ClassImp(mithep::BadEventsFilterMod)
 
 void
 mithep::BadEventsFilterMod::SlaveBegin()
 {
+  fBitMask = 0;
+
+  auto* file = GetCurrentFile();
+  if (!file)
+    return;
+
+  auto* nameTree = dynamic_cast<TTree*>(file->Get(fLabelTreeName));
+  if (!nameTree) {
+    SendError(kWarning, "SlaveBegin", "EvtSelData label names are not stored in the file.");
+    return;
+  }
+
+  std::vector<std::string>* filterLabels(new std::vector<std::string>);
+  TBranch* labelBranch(0);
+  nameTree->SetBranchAddress(fLabelBranchName, &filterLabels, &labelBranch);
+  if (!labelBranch) {
+    SendError(kWarning, "SlaveBegin", "EvtSelData label names are not stored in the file.");
+    return;
+  }
+
+  labelBranch->GetEntry(0);
+
+  for (auto& filt : fEnabledFilters) {
+    auto itr(std::find(filterLabels->begin(), filterLabels->end(), filt));
+    if (itr == filterLabels->end()) {
+      SendError(kWarning, "SlaveBegin", ("MET filter with label " + filt + " is not defined.").c_str());
+      continue;
+    }
+
+    fBitMask |= (1 << (itr - filterLabels->begin()));
+  }
+
+  delete nameTree;
+  delete filterLabels;
+
   if (GetFillHist()) {
-    AddTH1(hCounter, "hMETFilterCounter", "Number of events flagged bad", nEvtSelFilters, 0., double(nEvtSelFilters));
+    AddTH1(hCounter, "hMETFilterCounter", "Number of events flagged bad", fEnabledFilters.size(), 0., double(fEnabledFilters.size()));
+    int iX = 1;
+    for (unsigned iB = 0; iB != filterLabels->size(); ++iB) {
+      if (((fBitMask >> iB) & 1) != 0)
+        hCounter->GetXaxis()->SetBinLabel(iX++, filterLabels->at(iB).c_str());
+    }
   }
 }
 
@@ -21,26 +65,33 @@ mithep::BadEventsFilterMod::Process()
     return;
   }
 
+  Int_t word = evtSelData->metFiltersWord();
+
   if (GetFillHist()) {
-    Int_t w = evtSelData->metFiltersWord();
-    for (unsigned iF = 0; iF != nEvtSelFilters; ++iF) {
-      if ((w & 1) == 0)
-        hCounter->Fill(iF + 0.5);
-      w >>= 1;
+    int iX = 1;
+    for (unsigned iB = 0; iB != 8 * sizeof(Int_t); ++iB) {
+      if (((fBitMask >> iB) & 1) == 0)
+        continue;
+      
+      if (((word >> iB) & 1) == 0)
+        hCounter->Fill(iX - 0.5);
+
+      ++iX;
     }
   }
 
-  if ((fBitMask & evtSelData->metFiltersWord()) != fBitMask)
+  if ((fBitMask & word) != fBitMask)
     SkipEvent();
 
   return;
 }
 
 void
-mithep::BadEventsFilterMod::SetMask(EvtSelFilter f, Bool_t b)
+mithep::BadEventsFilterMod::SetFilter(char const* name, Bool_t enable/* = kTRUE*/)
 {
-  if (b)
-    fBitMask |= (1 << f);
-  else
-    fBitMask &= ~(1 << f);
+  auto itr(std::find(fEnabledFilters.begin(), fEnabledFilters.end(), name));
+  if (enable && itr == fEnabledFilters.end())
+    fEnabledFilters.emplace_back(name);
+  else if (!enable && itr != fEnabledFilters.end())
+    fEnabledFilters.erase(itr);
 }


### PR DESCRIPTION
Since MET filters change quite frequently, it is not very clever to hardcode the filter names. From version 043 we use a mechanism similar to the trigger's, where the list of filter names is saved as a separate tree in the Bambu file and the filter bits themselves are meaningless unless used in combination with this information. Accordingly BadEventsFilterMod now reads in this tree in the SlaveBegin function. Filter setup is therefore also text based (need to pass the filter name as an argument) instead of being done by hardcoded functions.
