### PR TITLE
removed CMSSW dependency from jet correction modules

### DIFF
--- a/Mods/src/JetCorrectionMod.cc
+++ b/Mods/src/JetCorrectionMod.cc
@@ -49,8 +49,6 @@ JetCorrectionMod::SlaveBegin()
   // fCorrector = 0 is alllowed but should not happen here - the module is useless in this case
   MakeCorrector();
 
-  fCorrector->Initialize();
-
   PublishObj(&fCorrectedJets);
 }
 

--- a/Mods/src/MetCorrectionMod.cc
+++ b/Mods/src/MetCorrectionMod.cc
@@ -46,10 +46,8 @@ MetCorrectionMod::SlaveBegin()
       MakeFormula(0);
   }
 
-  if (fApplyType1) {
+  if (fApplyType1)
     MakeJetCorrector();
-    fJetCorrector->Initialize();
-  }
 
   if (fApplyShift) {
     //XY shift formula: function of nVtx

--- a/Utils/interface/JetCorrector.h
+++ b/Utils/interface/JetCorrector.h
@@ -12,20 +12,73 @@
 
 #include "MitAna/DataTree/interface/Jet.h"
 
-#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+#include "TFormula.h"
 
 #include <vector>
 #include <algorithm>
-
-class FactorizedJetCorrector;
-class JetCorrectionUncertainty;
 
 namespace mithep {
 
   class JetCorrector {
   public:
-    JetCorrector() {}
-    virtual ~JetCorrector();
+    class Corrector {
+      // copied from CondFormats/JetMETObjects/interface/JetCorrectorParameters.h (7_4_X)
+    public:
+      enum VarType {
+        kJetEta,
+        kNPV,
+        kJetPt,
+        kJetPhi,
+        kJetE,
+        kJetEMF,
+        kJetA,
+        kRho,
+        kRelLepPt,
+        kPtRel,
+        nVarTypes
+      };
+
+      struct Record {
+        Record(unsigned nBinVars, unsigned nFormVars, unsigned nParameters, std::string const& inputLine);
+
+        std::vector<std::pair<float, float>> fBinVarLimits;
+        std::vector<std::pair<float, float>> fFormVarLimits;
+        std::vector<float> fParameters;
+      };
+      
+      Corrector(char const* fileName);
+      ~Corrector() {}
+
+      Jet::ECorr GetLevel() const { return fLevel; }
+      Double_t Eval(Double_t [nVarTypes]) const;
+      Bool_t GetEnabled() const { return fEnabled; }
+      Bool_t GetInterpolate() const { return fInterpolate; }
+
+      void SetEnabled(Bool_t b = kTRUE) { fEnabled = b; }
+      void SetInterpolate(Bool_t b = kTRUE) { fInterpolate = b; }
+      void SetUncertaintyUp(Bool_t b = kTRUE) { fUncertaintyUp = b; }
+      
+      static mithep::Jet::ECorr ParseLevelName(char const*);
+      static VarType ParseVariableName(char const*);
+
+    private:
+      Double_t EvalCorrection(Double_t [nVarTypes]) const;
+      Double_t EvalUncertainty(Double_t [nVarTypes]) const;
+      UInt_t FindRecord(Double_t [nVarTypes]) const;
+
+      Jet::ECorr fLevel{Jet::nECorrs};
+      std::vector<VarType> fBinningVariables{};
+      std::vector<VarType> fFormulaVariables{};
+      std::vector<Record> fRecords{};
+      Bool_t fIsResponse{kFALSE};
+      TFormula* fFormula{0};
+      Bool_t fEnabled{kTRUE};
+      Bool_t fInterpolate{kFALSE}; // turned off in CMSSW
+      Bool_t fUncertaintyUp{kTRUE};
+    };
+    
+    JetCorrector();
+    virtual ~JetCorrector() {}
 
     void AddParameterFile(char const* fileName);
     void ClearParameters();
@@ -33,28 +86,20 @@ namespace mithep {
     void SetUncertaintySigma(Double_t s) { fSigma = s; }
     void Initialize();
 
-    std::vector<mithep::Jet::ECorr> const& GetLevels() const { return fLevels; }
     mithep::Jet::ECorr GetMaxCorrLevel() const { return fMaxCorrLevel; }
     // Returns a vector of cumulative corrections, e.g. {L1, L1*L2, L1*L2*L3, ...}
-    std::vector<Float_t> CorrectionFactors(mithep::Jet&, Double_t rho = 0.) const;
+    std::vector<Float_t> CorrectionFactors(mithep::Jet const&, Double_t rho = 0.) const;
     // Returns the full correction (i.e. the last element of CorrectionFactors)
-    Float_t CorrectionFactor(mithep::Jet&, Double_t rho = 0.) const;
-    Float_t UncertaintyFactor(mithep::Jet&) const;
-    Bool_t IsInitialized() const;
-    Bool_t IsEnabled(mithep::Jet::ECorr l) const
-    { return l < fMaxCorrLevel && std::find(fLevels.begin(), fLevels.end(), l) != fLevels.end(); }
+    Float_t CorrectionFactor(mithep::Jet const&, Double_t rho = 0.) const;
+    Float_t UncertaintyFactor(mithep::Jet const&) const;
+    Bool_t IsEnabled(mithep::Jet::ECorr l) const;
 
     void Correct(mithep::Jet&, Double_t rho = 0.) const;
 
-    static mithep::Jet::ECorr TranslateLevel(char const* levelName);
-
   private:
-    std::vector<JetCorrectorParameters> fParameters{};
-    std::vector<mithep::Jet::ECorr> fLevels{};
+    std::vector<Corrector> fCorrectors{};
     mithep::Jet::ECorr fMaxCorrLevel = mithep::Jet::nECorrs;
-    FactorizedJetCorrector* fCorrector = 0;
-    JetCorrectionUncertainty* fUncertainty = 0;
-    Double_t fSigma = 0.;
+    Double_t fSigma = 0.; // uncertainty
 
     ClassDef(JetCorrector, 0)
   };


### PR DESCRIPTION
FactorizedJetCorrector, which was a part of CMSSW (but works as standalone libraries) was somehow causing problem in 76X. It was on our TODO list for some while to replace it with an original implementation - here it is.
